### PR TITLE
Removed inclusion of history.h when using editline

### DIFF
--- a/taskbrowser/TaskBrowser.cpp
+++ b/taskbrowser/TaskBrowser.cpp
@@ -99,7 +99,6 @@
 #ifdef USE_READLINE
 # ifdef USE_EDITLINE
 #  include <editline/readline.h>
-#  include <editline/history.h>
 # else
 #  include <readline/readline.h>
 #  include <readline/history.h>


### PR DESCRIPTION
ocl fails on OS X Maverics 10.9 with the following error:

ros_base_ws/src/ocl/taskbrowser/TaskBrowser.cpp:102:12: fatal error: 'editline/history.h' file not found
# include < editline/history.h >

This change allows compilation to succeed.

Does editline distribute a history.h on any other platform? 
