### PR TITLE
deployer: adding --noninteractive 

### DIFF
--- a/bin/deployer-funcs.cpp
+++ b/bin/deployer-funcs.cpp
@@ -83,6 +83,8 @@ int deployerParseCmdLine(int                        argc,
 		 "Show program version")
 		("daemon,d",
 		 "Makes this program a daemon such that it runs in the background. Returns 1 in case of success.")
+		("noninteractive,n",
+		 "Makes this program run without the interactive console.")
 		("start,s",
 		 po::value< std::vector<std::string> >(&scriptFiles),
 		 "Deployment XML or script file (eg 'config-file.xml' or 'script.ops')")

--- a/bin/deployer.cpp
+++ b/bin/deployer.cpp
@@ -179,8 +179,12 @@ int main(int argc, char** argv)
             if (result == false)
 		rc = -1;
 #ifdef USE_TASKBROWSER
-            // We don't start an interactive console when we're a daemon
-            if ( !deploymentOnlyChecked && !vm.count("daemon") ) {
+            if(vm.count("noninteractive")) {
+                RTT::OperationCaller<bool(void)> wait_for_interrupt = dc.getOperation("waitForInterrupt");
+                wait_for_interrupt();
+                dc.shutdownDeployment();
+            } else if ( !deploymentOnlyChecked && !vm.count("daemon")) {
+                // We don't start an interactive console when we're a daemon
                 OCL::TaskBrowser tb( &dc );
 
                 tb.loop();


### PR DESCRIPTION
This add an option to the deployer executable which enables it to be run without a taskbrowser and killed cleanly with SIGINT. This is really useful when launching a deployer via `roslaunch` and where interactivity is not necessary.
