### PR TITLE
logging: set keep_last_written_value to false

### DIFF
--- a/logging/Category.cpp
+++ b/logging/Category.cpp
@@ -13,7 +13,7 @@ Category::Category(const std::string& name,
                    log4cpp::Category* parent,
                    log4cpp::Priority::Value priority) :
         log4cpp::Category(name, parent, priority),
-        log_port( convertName(name) )
+        log_port( convertName(name) , false )
 {
 }
 


### PR DESCRIPTION
the keep_last_written_value option makes OutputPort::write not thread-safe, which might cause memory corruptions

Signed-off-by: Ruben Smits ruben.smits@intermodalics.eu
