### PR TITLE
taskbrowser: allow relocation/renaming of the taskbrowser history file 

### DIFF
--- a/taskbrowser/TaskBrowser.cpp
+++ b/taskbrowser/TaskBrowser.cpp
@@ -687,6 +687,7 @@ namespace OCL
           line_read(0),
           lastc(0), storedname(""), storedline(-1),
           usehex(false),
+          histfile(0),
           macrorecording(false)
     {
         tb = this;
@@ -703,7 +704,10 @@ namespace OCL
         rl_getc_function = &TaskBrowser::rl_getc;
 
         using_history();
-        if ( read_history(".tb_history") != 0 ) {
+        histfile = getenv("ORO_TB_HISTFILE");
+        if(histfile == 0)
+            histfile = ".tb_history";
+        if ( read_history(histfile) != 0 ) {
             read_history("~/.tb_history");
         }
 #ifdef USE_SIGNALS
@@ -730,7 +734,7 @@ namespace OCL
             {
                 free (line_read);
             }
-        if ( write_history(".tb_history") != 0 ) {
+        if ( write_history(histfile) != 0 ) {
             write_history("~/.tb_history");
         }
 #endif

--- a/taskbrowser/TaskBrowser.hpp
+++ b/taskbrowser/TaskBrowser.hpp
@@ -113,6 +113,9 @@ namespace OCL
         PTrace ptraces;
         PTrace straces;
 
+        //file to store history
+        char* histfile;
+
         //! We store the last parsed expression in order to keep
         //! it a little longer in memory, for example, when it's an 'send()' operation call.
         base::DataSourceBase::shared_ptr last_expr;


### PR DESCRIPTION
using the ORO_TB_HISTFILE environment flag

Signed-off-by: Ruben Smits ruben.smits@intermodalics.eu
