### PR TITLE
list components vertically in stead of on one line

### DIFF
--- a/taskbrowser/TaskBrowser.cpp
+++ b/taskbrowser/TaskBrowser.cpp
@@ -2111,7 +2111,7 @@ namespace OCL
             if ( !objlist.empty() )
                 for(vector<string>::iterator it = objlist.begin(); it != objlist.end(); ++it) {
                     if( peer->getPeer(*it) )
-                    	sresult << *it << "["<<getTaskStatusChar(peer->getPeer(*it))<<"] ";
+                    	sresult << *it << "["<<getTaskStatusChar(peer->getPeer(*it))<<"] \n";
                     else
                     	sresult << *it << "[X] ";
 	      }


### PR DESCRIPTION
I use a large number of orocos components and a vertical list would make it much clearer in that case:

So instead of:
component1 [F] component2 [E] component3 [X] component4 [R] component5 [R] component6 [S]

It will look like:
component1 [F]
component2 [E]
component3 [X]
component4 [R]
component5 [R]
component6 [S]
