### PR TITLE
taskbrowser: allow completion for members of properties of type PropertyBag

### DIFF
--- a/taskbrowser/TaskBrowser.cpp
+++ b/taskbrowser/TaskBrowser.cpp
@@ -544,7 +544,14 @@ namespace OCL
             Parser parser(GlobalEngine::Instance());
             DataSourceBase::shared_ptr result = parser.parseExpression( peerpath + component_found, context );
             if (result && !component.empty() ) {
-                vector<string> members = result->getMemberNames();
+                DataSource<PropertyBag>::shared_ptr bag = DataSource<PropertyBag>::narrow(result.get());
+                vector<string> members;
+                if(bag){
+                    members = bag->rvalue().getPropertyNames();
+                }
+                else{
+                    members = result->getMemberNames();
+                }
                 for (std::vector<std::string>::iterator i = members.begin(); i!= members.end(); ++i ) {
                     if ( string( component_found + "." + *i ).find( component ) == 0  )
                         completes.push_back( peerpath + component_found + "." + *i );
@@ -561,7 +568,14 @@ namespace OCL
                 Parser parser(GlobalEngine::Instance());
                 DataSourceBase::shared_ptr result = parser.parseExpression( peerpath + component, context );
                 if (result && !component.empty() ) {
-                    vector<string> members = result->getMemberNames();
+                    DataSource<PropertyBag>::shared_ptr bag = DataSource<PropertyBag>::narrow(result.get());
+                    vector<string> members;
+                    if(bag){
+                        members = bag->rvalue().getPropertyNames();
+                    }
+                    else{
+                        members = result->getMemberNames();
+                    }
                     for (std::vector<std::string>::iterator i = members.begin(); i!= members.end(); ++i ) {
                         if (component_found + "." != component ) // catch corner case.
                             completes.push_back( peerpath + component + "." + *i );


### PR DESCRIPTION
Tab completion was not possible for members of properties of type propertybag. This PR allow this.

Signed-off-by: Ruben Smits <ruben.smits@intermodalics.eu>