### PR TITLE
deployment: added property and an operation to influence the wait period policy of periodic activities

### DIFF
--- a/deployment/DeploymentComponent.cpp
+++ b/deployment/DeploymentComponent.cpp
@@ -95,6 +95,7 @@ namespace OCL
 
     DeploymentComponent::DeploymentComponent(std::string name, std::string siteFile)
         : RTT::TaskContext(name, Stopped),
+          defaultWaitPeriodPolicy(ORO_WAIT_ABS),
           autoUnload("AutoUnload",
                      "Stop, cleanup and unload all components loaded by the DeploymentComponent when it is destroyed.",
                      true),
@@ -108,6 +109,7 @@ namespace OCL
           nextGroup(0)
     {
         this->addProperty( "RTT_COMPONENT_PATH", compPath ).doc("Locations to look for components. Use a colon or semi-colon separated list of paths. Defaults to the environment variable with the same name.");
+        this->addProperty( "DefaultWaitPeriodPolicy", defaultWaitPeriodPolicy ).doc("The default value for the wait period policy property for threads of newly created activities (ORO_WAIT_ABS or ORO_WAIT_REL).");
         this->addProperty( autoUnload );
         this->addAttribute( target );
 
@@ -206,6 +208,8 @@ namespace OCL
 			.arg("Timeout", "The timeout of the activity (set to zero for no timeout).")
 			.arg("Priority", "The priority of the activity.")
 			.arg("SchedType", "The scheduler type of the activity.");
+
+        this->addOperation("setWaitPeriodPolicy", &DeploymentComponent::setWaitPeriodPolicy, this, ClientThread).doc("Sets the wait period policy of an existing component thread.").arg("CompName", "The name of the Component.").arg("Policy", "The new policy (ORO_WAIT_ABS or ORO_WAIT_REL).");
 
         valid_names.insert("AutoUnload");
         valid_names.insert("UseNamingService");
@@ -2058,11 +2062,31 @@ namespace OCL
             return false;
         }
 
+        // assign default wait period policy to newly created activity
+        newact->thread()->setWaitPeriodPolicy(defaultWaitPeriodPolicy);
+
         // this must never happen if component is running:
         assert( peer->isRunning() == false );
         delete compmap[comp_name].act;
         compmap[comp_name].act = newact;
 
+        return true;
+    }
+
+    bool DeploymentComponent::setWaitPeriodPolicy(const std::string& comp_name, int policy)
+    {
+        if ( !compmap.count(comp_name) ) {
+            log(Error) << "Can't setWaitPeriodPolicy: component "<<comp_name<<" not found."<<endlog();
+            return false;
+        }
+
+        RTT::base::ActivityInterface *activity = compmap[comp_name].instance->getActivity();
+        if ( !activity ) {
+            log(Error) << "Can't setWaitPeriodPolicy: component "<<comp_name<<" has no activity (yet)."<<endlog();
+            return false;
+        }
+
+        activity->thread()->setWaitPeriodPolicy(policy);
         return true;
     }
 

--- a/deployment/DeploymentComponent.hpp
+++ b/deployment/DeploymentComponent.hpp
@@ -93,6 +93,7 @@ namespace OCL
          */
         RTT::PropertyBag root;
         std::string compPath;
+        int defaultWaitPeriodPolicy;
         RTT::Property<bool> autoUnload;
         RTT::Attribute<bool> validConfig;
         RTT::Constant<int> sched_RT;
@@ -630,6 +631,17 @@ namespace OCL
                          double period, int priority,
                          int scheduler, unsigned cpu_affinity,
                          const std::string& master_name = "");
+
+        /**
+         * (Re-)set the wait period policy of a component's thread.
+         *
+         * @param comp_name The name of the component to change.
+         * @param policy    The new policy \a ORO_WAIT_ABS or \a ORO_WAIT_REL
+         *
+         * @return false if one of the parameters does not match.
+         */
+        bool setWaitPeriodPolicy(const std::string& comp_name,
+                         int policy);
 
         /**
          * Load a (partial) application XML configuration from disk. The


### PR DESCRIPTION
This pull request adds the `DefaultWaitPeriodPolicy` property to the DeploymentComponent to influence the wait period policy of newly created activities. I also added an operation `setWaitPeriodPolicy(name, policy) to reset the wait period policy of any component after creation.

From fosi.h:
```cpp
#define ORO_WAIT_ABS 0 /** rtos_task_wait_period may wait less than the duration required to pad the period to 
                            catch-up with overrun timesteps (wait according to an absolute timeline) */
#define ORO_WAIT_REL 1 /** rtos_task_wait_period will always pad the current timestep to the desired period, 
                            regardless of previous overruns (wait according to a relative timeline) */
```

The constants `ORO_WAIT_ABS` and `ORO_WAIT_REL` have been added to the RTT::types::GlobalsRepository in https://github.com/orocos-toolchain/rtt/commit/a480b039d1440861485ebbd5edacae6a4c736d2f.

Orocos users should be aware of the implications of the two wait policy settings, especially for applications that run day and night or during daylight saving time clock changes. In fact, we should clean up RTT to use a monotonic clock source instead of absolute clock for periodic activities.