### PR TITLE
Fixed underlying service call to package rtt_rospack in rtt_ros.find_rospack()

### DIFF
--- a/lua/modules/rttros.lua
+++ b/lua/modules/rttros.lua
@@ -36,7 +36,7 @@ function find_rospack(package)
       depl = rttlib.findpeer("deployer") or rttlib.findpeer("Deployer")
       if not depl then error("find_rospack: failed to find a deployer") end
       depl:import("rtt_rospack")
-      rtt_rospack_find=rtt.provides("rospack"):getOperation("find")
+      rtt_rospack_find=rtt.provides("ros"):getOperation("find")
    end
    local res = rtt_rospack_find(package)
    if res~="" then return res else return false end


### PR DESCRIPTION
The rtt_rospack package (and most other plugins provided by rtt_ros_integration) adds its operation `find` to the global service named `ros`.