### PR TITLE
Read default connpolicy from deployment XML file

### DIFF
--- a/deployment/DeploymentComponent.cpp
+++ b/deployment/DeploymentComponent.cpp
@@ -828,7 +828,20 @@ namespace OCL
                         assert( cp_prop.ready() );
                         if ( cp_prop.compose( comp ) ) {
                             //It's a connection policy.
-                            conmap[cp_prop.getName()].policy = cp_prop.get();
+#if defined(RTT_VERSION_GTE)
+#if RTT_VERSION_GTE(2,8,99)
+                            // Set default ConnPolicy
+                            if (cp_prop.getName() == "Default") {
+                                RTT::ConnPolicy::Default() = cp_prop.get();
+                            } else {
+#endif
+#endif
+                                conmap[cp_prop.getName()].policy = cp_prop.get();
+#if defined(RTT_VERSION_GTE)
+#if RTT_VERSION_GTE(2,8,99)
+                            }
+#endif
+#endif
                             log(Debug) << "Saw connection policy " << (*it)->getName() << endlog();
                             continue;
                         }

--- a/deployment/DeploymentComponent.cpp
+++ b/deployment/DeploymentComponent.cpp
@@ -1303,6 +1303,11 @@ namespace OCL
             ConnectionData *connection =  &(it->second);
             std::string connection_name = it->first;
 
+            // Set the connection name as default name_id if none was given explicitly
+            if (connection->policy.name_id.empty()) {
+                connection->policy.name_id = connection_name;
+            }
+
             if ( connection->ports.size() == 1 ){
                 string owner = connection->owners[0]->getName();
                 string portname = connection->ports.front()->getName();

--- a/deployment/tests/deployment.cpf
+++ b/deployment/tests/deployment.cpf
@@ -14,6 +14,14 @@
     <simple name="AutoStart" type="boolean"><value>1</value></simple>
   </struct>
 
+  <!-- Default connection policy -->
+  <struct name="Default" type="ConnPolicy">
+    <simple name="type" type="long"><value>0</value></simple>
+    <simple name="size" type="long"><value>99</value></simple>
+    <simple name="buffer_policy" type="long"><value>4</value></simple>
+    <simple name="lock_policy" type="long"><value>1</value></simple>
+  </struct>
+
   <!-- Connection policy -->
   <struct name="AConnection" type="ConnPolicy">
     <simple name="type" type="short"><value>1</value></simple>

--- a/deployment/tests/main.cpp
+++ b/deployment/tests/main.cpp
@@ -72,6 +72,7 @@ public:
 int ORO_main(int, char**)
 {
     RTT::Logger::Instance()->setLogLevel(RTT::Logger::Info);
+    int exit_code = 0;
 
     MyTask t1("ComponentA");
     MyTask t2("ComponentB");
@@ -88,9 +89,19 @@ int ORO_main(int, char**)
         dc.addPeer( &p );
         dc.addPeer( &r );
         dc.kickStart("deployment.cpf");
-        TaskBrowser tb(&dc);
 
+#if defined(RTT_VERSION_GTE)
+#if RTT_VERSION_GTE(2,8,99)
+        if (RTT::ConnPolicy::Default().size != 99 ||
+            RTT::ConnPolicy::Default().buffer_policy != RTT::Shared) {
+            log(Fatal) << "Default ConnPolicy not set correctly!" << endlog();
+            exit_code = 1;
+        }
+#endif
+#endif
+
+        TaskBrowser tb(&dc);
         tb.loop();
     }
-    return 0;
+    return exit_code;
 }


### PR DESCRIPTION
This PR adds a new element to the XML deployment file for setting the default connection policy, if OCL is compiled against a version of RTT that has a default policy (see orocos-toolchain/rtt#114). The values of the default connection policy are copied over to every new ConnPolicy instance created.

The patch does not introduce a new XML tag, but a ConnPolicy element with the special name "Default" is interpreted as the new process-wide default policy. There is a small risk that this name is already in use to name connections in some existing XML files, but even then this patch would not necessarily break the deployment except that all other connections without an explicit ConnPolicy element would also use this default ConnPolicy.