### PR TITLE
deployer: do not run a TaskBrowser if the deployer was invoked without a tty input

### DIFF
--- a/bin/deployer-corba.cpp
+++ b/bin/deployer-corba.cpp
@@ -38,6 +38,8 @@
 #include <deployment/CorbaDeploymentComponent.hpp>
 #include <rtt/transports/corba/TaskContextServer.hpp>
 #include <iostream>
+#include <unistd.h>
+#include <stdio.h>
 #include "deployer-funcs.hpp"
 
 #include <rtt/transports/corba/corba.h>
@@ -179,7 +181,7 @@ int main(int argc, char** argv)
                scripts stops after the first failed script, and -1 is returned.
                Whether a script failed or all scripts succeeded, in non-daemon
                and non-checking mode the TaskBrowser will be run to allow
-               inspection.
+               inspection if the input is a tty.
              */
             bool result = true;
             for (std::vector<std::string>::const_iterator iter=scriptFiles.begin();
@@ -215,13 +217,19 @@ int main(int argc, char** argv)
             }
             rc = (result ? 0 : -1);
 
+#ifdef USE_TASKBROWSER
             if ( !deploymentOnlyChecked && !vm.count("daemon") ) {
-                 OCL::TaskBrowser tb( &dc );
-                 tb.loop();
+                if (isatty(fileno(stdin))) {
+                    OCL::TaskBrowser tb( &dc );
+                    tb.loop();
+                } else {
+                    dc.waitForInterrupt();
+                }
 
-                 // do it while CORBA is still up in case need to do anything remote.
-                 dc.shutdownDeployment();
+                // do it while CORBA is still up in case need to do anything remote.
+                dc.shutdownDeployment();
             }
+#endif
 
             TaskContextServer::ShutdownOrb();
 

--- a/deployment/DeploymentComponent.hpp
+++ b/deployment/DeploymentComponent.hpp
@@ -231,18 +231,6 @@ namespace OCL
          */
         base::PortInterface* stringToPort(std::string const& names);
 
-        /**
-         * Waits for any signal and then returns.
-         * @return false if this function could not install a signal handler.
-         */
-        bool waitForSignal(int signumber);
-
-        /**
-         * Waits for SIGINT and then returns.
-         * @return false if this function could not install a signal handler.
-         */
-        bool waitForInterrupt();
-
     public:
         /**
          * Constructs and configures this component.
@@ -930,6 +918,18 @@ namespace OCL
          * then that will be executed, otherwise nothing occurs.
          */
         void shutdownDeployment();
+
+        /**
+         * Waits for any signal and then returns.
+         * @return false if this function could not install a signal handler.
+         */
+        bool waitForSignal(int signumber);
+
+        /**
+         * Waits for SIGINT and then returns.
+         * @return false if this function could not install a signal handler.
+         */
+        bool waitForInterrupt();
 
     };
 


### PR DESCRIPTION
For backwards-compatibility there are still small differences between running in daemon mode, rttscript and running a deployer without a tty:

### `deployer --daemon ...`
Main process exits after the deployment. One of the scripts need to block or the whole process terminates.

It should be noted that the deployer is still not a "daemon" process in the usual sense, as it does not detach from the current session (see See http://codingfreak.blogspot.com/2012/03/daemon-izing-process-in-linux.html).

I would consider the daemon mode as broken as long as the deployer does not fork and wait for a signal after all deployment scripts have been run successfully, even if waitForInterrupt() is not explicitly called.

### `rttscript ...`
Actually the same as `deployer --daemon`, but in this case it might be fine to terminate after all scripts run successfully, so that the tool is useful for other tasks than pure deployment.

### `deployer ... </dev/null`
Without this patch and without a tty as an input the TaskBrowser exits and the deployer shuts down immediately. With this patch we simply call waitForInterrupt() instead, so that the process is running without a TaskBrowser but can still be terminated with SIGINT (reacting on SIGTERM would require an additional patch). This allows to run a normal deployer without additional command line options and without the need to patch the deployment scripts, e.g. from init scripts or non-interactively in CI environments.