### PR TITLE
deployer: Also terminate cleanly on SIGTERM and SIGHUP

### DIFF
--- a/deployment/DeploymentComponent.hpp
+++ b/deployment/DeploymentComponent.hpp
@@ -232,13 +232,21 @@ namespace OCL
         base::PortInterface* stringToPort(std::string const& names);
 
         /**
+         * Waits for any signal in the list and then returns.
+         * @param sigs a pointer to the first element in the list of signals
+         * @param the number of signals in the list
+         * @return false if this function could not install a signal handler.
+         */
+        bool waitForSignals(int *sigs, std::size_t sig_count);
+
+        /**
          * Waits for any signal and then returns.
          * @return false if this function could not install a signal handler.
          */
         bool waitForSignal(int signumber);
 
         /**
-         * Waits for SIGINT and then returns.
+         * Waits for SIGINT, SIGTERM or SIGHUP and then returns.
          * @return false if this function could not install a signal handler.
          */
         bool waitForInterrupt();


### PR DESCRIPTION
Added a new method `DeploymentComponent::waitForSignals()` to wait for multiple signals.

The default `waitForInterrupt()` implementation installs three handlers for SIGINT, SIGTERM and SIGHUP now. SIGINT is typically only used to catch Ctrl-C on stdin, while external processes usually send the SIGTERM signal to request a shutdown (like the init daemon, roslaunch etc.).