### PR TITLE
env-hooks: install env-hook for ocl-lua to etc/orocos/OROCOS_TARGET/profile.d

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,7 +222,14 @@ ENDIF( DISPLAY_FLAGS )
 
 INSTALL(FILES package.xml DESTINATION share/ocl)
 
-# Install an env-hook if catkin is found
+# Install an env-hook
+configure_file(env-hooks/00.ocl-lua.sh.in ${CMAKE_CURRENT_BINARY_DIR}/env-hooks/00.ocl-lua.sh @ONLY)
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/env-hooks/00.ocl-lua.sh
+  DESTINATION etc/orocos/${OROCOS_TARGET}/profile.d
+)
+
+# Install a catkin env-hook if catkin is installed
 find_package(catkin QUIET)
 if(catkin_FOUND)
   catkin_add_env_hooks(00.ocl-lua SHELLS sh DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/env-hooks)

--- a/env-hooks/00.ocl-lua.sh.in
+++ b/env-hooks/00.ocl-lua.sh.in
@@ -1,12 +1,15 @@
 #!/bin/sh
 
-if [ "x$LUA_PATH" = "x" ]; then
-    LUA_PATH=";"
+if [ -d "@CMAKE_INSTALL_PREFIX@/share/lua/5.1" ]; then
+    if [ "x$LUA_PATH" = "x" ]; then
+        LUA_PATH=";"
+    fi
+    export LUA_PATH="$LUA_PATH;@CMAKE_INSTALL_PREFIX@/share/lua/5.1/?.lua"
 fi
-export LUA_PATH="$LUA_PATH;@CMAKE_INSTALL_PREFIX@/share/lua/5.1/?.lua"
 
-if [ "x$LUA_CPATH" = "x" ]; then
-    LUA_CPATH=";"
+if [ -d "@CMAKE_INSTALL_PREFIX@/lib/lua/5.1" ]; then
+    if [ "x$LUA_CPATH" = "x" ]; then
+        LUA_CPATH=";"
+    fi
+    export LUA_CPATH="$LUA_CPATH;@CMAKE_INSTALL_PREFIX@/lib/lua/5.1/?.so"
 fi
-export LUA_CPATH="$LUA_CPATH;@CMAKE_INSTALL_PREFIX@/lib/lua/5.1/?.so"
-


### PR DESCRIPTION
The env-hook adds the installation folders of the ocl-lua modules to the LUA_PATH/LUA_CPATH environment variables.

The scripts in etc/orocos/OROCOS_TARGET/profile.de will be sourced in lexical order by a new [setup.sh](https://github.com/meyerj/orocos_toolchain/blob/installation-script/setup.sh)
script located in the orocos_toolchain repository.
