### PR TITLE
deployment: do not release the ComponentLoader during destruction of the DeploymentComponent

### DIFF
--- a/deployment/DeploymentComponent.cpp
+++ b/deployment/DeploymentComponent.cpp
@@ -283,7 +283,6 @@ namespace OCL
       if ( autoUnload.get() ) {
           kickOutAll();
       }
-      ComponentLoader::Release();
     }
 
     bool DeploymentComponent::waitForInterrupt() {


### PR DESCRIPTION
The `ComponentLoader::Release()` command was added in b91a085d798d153bf6fad2d0d647495d7d06e664, but the class' definition and implementation has been moved from OCL to RTT in 1a19d57ca4d9b0b137150cca5d3ff10d327e8c32.

There could be multiple DeploymentComponent instances in a single process, so destruction of one of them should not cleanup the global ComponentLoader. The `RTT::os::StartStopManager` already takes care of this. See https://github.com/orocos-toolchain/rtt/blob/master/rtt/deployment/ComponentLoader.cpp#L275.