### PR TITLE
lua: fixed cleanup of TaskContexts with the tc_cleanup function

### DIFF
--- a/lua/modules/rttlib.lua
+++ b/lua/modules/rttlib.lua
@@ -584,7 +584,8 @@ function tc_cleanup()
    local function cleanup_attr(pname)
       local attr = TaskContext.getAttribute(tc, pname)
       TaskContext.removeAttribute(tc, pname)
-      attr:delete()
+      -- TaskContext.removeAttribute invalidates the pointer stored in attr!
+      --attr:delete()
    end
 
    local function cleanup_port(pname)


### PR DESCRIPTION
Attributes are owned by the TaskContext and `TaskContext::removeAttribute()` or the respective Lua wrapper already destroys the instance returned by `TaskContext::getAttribute()`. The additional `attr:delete()` command triggers a segfault if the component has at least one attribute. The implementation of attributes is different from ports and properties with that respect, which are not cloned when they are added to the component interface.

On the other hand while adding attributes the instance created by Lua in `Attribute_new()` should be destroyed after it has been cloned and added to the TaskContext or `TaskContext_addAttribute()` must exchange the instance pointer in the Lua stack with the clone (not sure if this is possible).