### PR TITLE
change deployer components group assignment logic

### DIFF
--- a/deployment/DeploymentComponent.cpp
+++ b/deployment/DeploymentComponent.cpp
@@ -982,6 +982,10 @@ namespace OCL
                                 continue;
                             }
                             c = compmap[(*it)->getName()].instance;
+
+                            // The component is added to a group only when it is loaded, not when a service is added or changed.
+                            compmap[(*it)->getName()].group = group;
+                            log(Info) << "Component " << (*it)->getName() << " added to group " << group << "." << endlog();
                         } else {
                             // If the user added c as a peer (outside of Deployer) store the pointer
                             compmap[(*it)->getName()].instance = c;
@@ -1197,11 +1201,6 @@ namespace OCL
                         if (!ret) {
                             log(Error) << "Failed to store deployment properties for component " << comp.getName() <<endlog();
                             valid = false;
-                        }
-                        else
-                        {
-                            log(Info) << "Added component " << (*it)->getName() << " to group " << group << endlog();
-                            compmap[(*it)->getName()].group = group;
                         }
                     }
 


### PR DESCRIPTION
The component is added to a group only when it is loaded, not when a service is added or changed.

Use case:
- first configuration xml loads two components A and B.  B has a slaveActivity while A has a master Activity.
- second configuration xml loads other components and add a port to the component A. Therefore A is moved to the second group.

When shutting down the Deployer unload groups in the reverse order.
With the current logic A is unloaded when the second group is unloaded but B that is a slaveActivity is unloaded only when the first group is unloaded.