### PR TITLE
Use orocos macro for helloworld executable

### DIFF
--- a/helloworld/CMakeLists.txt
+++ b/helloworld/CMakeLists.txt
@@ -6,7 +6,7 @@ IF ( BUILD_HELLOWORLD )
     FILE( GLOB SRCS [^.]*.cpp )
     FILE( GLOB HPPS [^.]*.hpp )
 
-    ADD_EXECUTABLE( helloworld ${SRCS} )
+    orocos_executable( helloworld ${SRCS} )
     orocos_component( orocos-ocl-helloworld ${SRCS} )
     SET_TARGET_PROPERTIES( orocos-ocl-helloworld PROPERTIES
       SOVERSION ${OCL_SOVERSION}


### PR DESCRIPTION
I got the following compile error without this: `/home/rsmits/my_ws/src/orocos_toolchain/ocl/helloworld/HelloWorld.cpp:8:25: fatal error: rtt/os/main.h: No such file or directory`