### PR TITLE
Minor logging fixes

### DIFF
--- a/logging/Category.cpp
+++ b/logging/Category.cpp
@@ -108,7 +108,11 @@ void Category::_logUnconditionally2(log4cpp::Priority::Value priority,
 
 void Category::callAppenders(const OCL::logging::LoggingEvent& event) throw()
 {
-    log_port.write( event );
+    // only write if the port is connected
+    if (log_port.connected())
+    {
+        log_port.write( event );
+    }
 
     // let our parent categories append (if they want to)
     if (getAdditivity() && (getParent() != NULL))

--- a/logging/Category.hpp
+++ b/logging/Category.hpp
@@ -162,7 +162,12 @@ protected:
     RTT::OutputPort<OCL::logging::LoggingEvent>   log_port;
     /// for access to \a log_port
     friend class OCL::logging::LoggingService;
-    
+public:
+    const RTT::OutputPort<OCL::logging::LoggingEvent>& get_log_port() const
+    {
+        return log_port;
+    };
+
 public:
     /** Connect \a otherPort to \a log_port.
          Typically used by unit test code to directly syphon off logging events.

--- a/logging/LoggingService.cpp
+++ b/logging/LoggingService.cpp
@@ -101,6 +101,7 @@ bool LoggingService::configureHook()
             }
             
             log(Debug) << "Getting category '" << categoryName << "'" << endlog();
+            // will create category if not exists
             log4cpp::Category& category =
                 log4cpp::Category::getInstance(categoryName);
 
@@ -142,6 +143,7 @@ bool LoggingService::configureHook()
             // "" == categoryName implies the root category.
 
             log(Debug) << "Getting category '" << categoryName << "'" << endlog();
+            // will create category if not exists
             log4cpp::Category& category =
             log4cpp::Category::getInstance(categoryName);
 
@@ -171,20 +173,13 @@ bool LoggingService::configureHook()
             std::string categoryName    = association->getName();
             std::string appenderName    = association->value();
             
-            // find category 
-            log4cpp::Category* p = log4cpp::HierarchyMaintainer::getDefaultMaintainer().getExistingInstance(categoryName);
+            // find category - will create category if not exists
+            log4cpp::Category& p   = log4cpp::Category::getInstance(categoryName);
             OCL::logging::Category* category =
-                dynamic_cast<OCL::logging::Category*>(p);
+                dynamic_cast<OCL::logging::Category*>(&p);
             if (0 == category)
             {
-                if (0 != p)
-                {
-                    log(Error) << "Category '" << categoryName << "' is not an OCL category: type is '" << typeid(*p).name() << "'" << endlog();
-                }
-                else
-                {
-                    log(Error) << "Category '" << categoryName << "' does not exist!" << endlog();
-                }
+                log(Error) << "Category '" << categoryName << "' is not an OCL category: type is '" << typeid(p).name() << "'" << endlog();
                 ok = false;
                 break;
             }

--- a/logging/LoggingService.cpp
+++ b/logging/LoggingService.cpp
@@ -295,15 +295,19 @@ void LoggingService::logCategories()
     {
         std::stringstream str;
 
+        OCL::logging::Category* c = dynamic_cast<OCL::logging::Category*>(*iter);
         str
             << "Category '" << (*iter)->getName() << "', level="
             << log4cpp::Priority::getPriorityName((*iter)->getPriority())
             << ", typeid='"
             << typeid(*iter).name()
             << "', type really is '" 
-            << std::string(0 != dynamic_cast<OCL::logging::Category*>(*iter)
-                           ? "OCL::Category" : "log4cpp::Category")
+            << std::string(0 != c ? "OCL::Category" : "log4cpp::Category")
             << "', additivity=" << (const char*)((*iter)->getAdditivity()?"yes":"no");
+        if (0 != c)
+        {
+            str << ", port=" << (c->log_port.connected() ? "connected" : "not connected");
+        }
         log4cpp::Category* p = (*iter)->getParent();
         if (p)
         {

--- a/logging/LoggingService.hpp
+++ b/logging/LoggingService.hpp
@@ -35,10 +35,42 @@ public:
        - specify priority of logging of this component
 
        services for other components
-       - method to set priority of any category
-       - method to get priority of any category
        - method to log to a category
     */
+
+    // Correspond to log4cpp::Priority::PriorityLevel
+    RTT::Attribute<int>         level_EMERG_attr;
+    RTT::Attribute<int>         level_FATAL_attr;
+    RTT::Attribute<int>         level_ALERT_attr;
+    RTT::Attribute<int>         level_CRIT_attr;
+    RTT::Attribute<int>         level_ERROR_attr;
+    RTT::Attribute<int>         level_WARN_attr;
+    RTT::Attribute<int>         level_NOTICE_attr;
+    RTT::Attribute<int>         level_INFO_attr;
+    RTT::Attribute<int>         level_DEBUG_attr;
+    RTT::Attribute<int>         level_NOTSET_attr;
+
+    /// @copydoc OCL::logging::LoggingService::setCategoryPriority()
+    RTT::Operation<bool(std::string,int)>       setCategoryPriority_mtd;
+    /** Set the priority of category \a name to \a priority
+     * If the category does not exist then an error is logged and nothing
+     * else occurs.
+     * @param name Category name
+     * @param priority Priority level (one of level_XXX_attr)
+     * @return true if category \a name exists and the category was set,
+     * otherwise false
+     */
+    bool setCategoryPriority(const std::string& name, const int priority);
+
+    /// @copydoc OCL::logging::LoggingService::getCategoryPriorityName()
+    RTT::Operation<std::string(std::string)>    getCategoryPriorityName_mtd;
+    /** Get the priority name of category \a name
+     * @return if category \a name exists and the priority of the category is
+     * known then the descriptive name (e.g. "INFO") of the priority, otherwise
+     * if the category \a name exists but the priority is not known then
+     * "UNKNOWN PRIORITY", otherwise "UNKNOWN CATEGORY"
+     */
+    std::string getCategoryPriorityName(const std::string& name);
 
 protected:
     // list of all category levels


### PR DESCRIPTION
Add additional debug output.

Support setting/getting the logging level on a category.

Support creating a category when connecting it to an appender, just as one is created when setting additivity or the logging level.

Add an optimization to only write to a log port that is connected.