### PR TITLE
Prevent double-configure issues when checking deployments

### DIFF
--- a/bin/cdeployer.cpp
+++ b/bin/cdeployer.cpp
@@ -187,12 +187,17 @@ int main(int argc, char** argv)
                 {
                     if ( (*iter).rfind(".xml",string::npos) == (*iter).length() - 4 || (*iter).rfind(".cpf",string::npos) == (*iter).length() - 4) {
                         if ( deploymentOnlyChecked ) {
-                            if (!dc.loadComponents( (*iter) )) {
+                            bool loadOk         = true;
+                            bool configureOk    = true;
+                            bool startOk        = true;
+                            if (!dc.kickStart2( (*iter), false, loadOk, configureOk, startOk )) {
                                 result = false;
-                                log(Error) << "Failed to load file: '"<< (*iter) <<"'." << endlog();
-                            } else if (!dc.configureComponents()) {
-                                result = false;
-                                log(Error) << "Failed to configure file: '"<< (*iter) <<"'." << endlog();
+                                if (!loadOk) {
+                                    log(Error) << "Failed to load file: '"<< (*iter) <<"'." << endlog();
+                                } else if (!configureOk) {
+                                    log(Error) << "Failed to configure file: '"<< (*iter) <<"'." << endlog();
+                                }
+                                (void)startOk;      // unused - avoid compiler warning
                             }
                             // else leave result=true and continue
                         } else {

--- a/bin/deployer-corba.cpp
+++ b/bin/deployer-corba.cpp
@@ -192,12 +192,17 @@ int main(int argc, char** argv)
                 {
                     if ( (*iter).rfind(".xml",string::npos) == (*iter).length() - 4 || (*iter).rfind(".cpf",string::npos) == (*iter).length() - 4) {
                         if ( deploymentOnlyChecked ) {
-                            if (!dc.loadComponents( (*iter) )) {
+                            bool loadOk         = true;
+                            bool configureOk    = true;
+                            bool startOk        = true;
+                            if (!dc.kickStart2( (*iter), false, loadOk, configureOk, startOk )) {
                                 result = false;
-                                log(Error) << "Failed to load file: '"<< (*iter) <<"'." << endlog();
-                            } else if (!dc.configureComponents()) {
-                                result = false;
-                                log(Error) << "Failed to configure file: '"<< (*iter) <<"'." << endlog();
+                                if (!loadOk) {
+                                    log(Error) << "Failed to load file: '"<< (*iter) <<"'." << endlog();
+                                } else if (!configureOk) {
+                                    log(Error) << "Failed to configure file: '"<< (*iter) <<"'." << endlog();
+                                }
+                                (void)startOk;      // unused - avoid compiler warning
                             }
                             // else leave result=true and continue
                         } else {

--- a/bin/deployer.cpp
+++ b/bin/deployer.cpp
@@ -181,12 +181,17 @@ int main(int argc, char** argv)
                 {
                     if ( (*iter).rfind(".xml",std::string::npos) == (*iter).length() - 4 || (*iter).rfind(".cpf",std::string::npos) == (*iter).length() - 4) {
                         if ( deploymentOnlyChecked ) {
-                            if (!dc.loadComponents( (*iter) )) {
+                            bool loadOk         = true;
+                            bool configureOk    = true;
+                            bool startOk        = true;
+                            if (!dc.kickStart2( (*iter), false, loadOk, configureOk, startOk )) {
                                 result = false;
-                                log(Error) << "Failed to load file: '"<< (*iter) <<"'." << endlog();
-                            } else if (!dc.configureComponents()) {
-                                result = false;
-                                log(Error) << "Failed to configure file: '"<< (*iter) <<"'." << endlog();
+                                if (!loadOk) {
+                                    log(Error) << "Failed to load file: '"<< (*iter) <<"'." << endlog();
+                                } else if (!configureOk) {
+                                    log(Error) << "Failed to configure file: '"<< (*iter) <<"'." << endlog();
+                                }
+                                (void)startOk;      // unused - avoid compiler warning
                             }
                             // else leave result=true and continue
                         } else {

--- a/deployment/DeploymentComponent.hpp
+++ b/deployment/DeploymentComponent.hpp
@@ -759,6 +759,28 @@ namespace OCL
         bool kickStart(const std::string& file_name);
 
         /**
+         * This function runs loadComponents and configureComponents, and
+         * optionally startComponents, in a row, given no failures occur along
+         * the way.
+         *
+         * @param configurationfile The file to load
+         * @param doStart True to run startComponents, otherwise the components
+         * are only loaded and configured.
+         * @param loadOk True if successfully loaded the file
+         * @param configureOk True if successfully configured all components
+         * loaded from the file
+         * @param startOk True if did not want to start (doStart==false) or
+         * did want to start (doStart==true) and successfully started all
+         * components loaded from the file, otherwise false
+         * @return (loadOk && configureOk && (!doStart || startOk))
+         */
+        bool kickStart2(const std::string& configurationfile,
+                        const bool         doStart,
+                        bool&              loadOk,
+                        bool&              configureOk,
+                        bool&              startOk);
+
+        /**
          * Stop, cleanup and unload a single component which were loaded by this component.
          * @param comp_name name of the component.
          * @return true if successfully stopped, cleaned and unloaded


### PR DESCRIPTION
The existing "check" approach calls loadComponents(file), which loaded all components from "file" into the next group, and then called configureComponents(), which configured *all* groups. This results in configuring components in some layers multiple times, if multiple files are loaded. e.g.

- kickStart(file1);
- kickStart(file2);

results in

- load components from file 1
- configure components from file 1
- load components from file 2
- configure components from file 1 // BAD!
- configure components from file 2

The fix is to use the internal load/configure/start functions that know about groups, and which only load/configure/start the components of the current group. This effectively needs a kickStart() that knows whether the user wants to start components or not (which is the only net difference between a deployment run with and without checking.