### PR TITLE
deployment: Pass component name to FileDescriptorActivity ctor

### DIFF
--- a/deployment/DeploymentComponent.cpp
+++ b/deployment/DeploymentComponent.cpp
@@ -2116,7 +2116,7 @@ namespace OCL
                         }
 			else if ( act_type == "FileDescriptorActivity") {
 				using namespace RTT::extras;
-                newact = new FileDescriptorActivity(scheduler, priority, period, cpu_affinity, 0);
+                newact = new FileDescriptorActivity(scheduler, priority, period, cpu_affinity, 0, comp_name);
 				FileDescriptorActivity* fdact = dynamic_cast< RTT::extras::FileDescriptorActivity* > (newact);
 				if (fdact) fdact->setTimeout(period);
 				else newact = 0;


### PR DESCRIPTION
Without this the thread name is set to "FileDescriptorActivity", which
is useless when multiple FDAs are present in the deployment.

The fix is to pass the component name through to the FDA, the same as
with the other Activity derived classes.