### PR TITLE
Fix thread naming

### DIFF
--- a/deployment/DeploymentComponent.cpp
+++ b/deployment/DeploymentComponent.cpp
@@ -2093,10 +2093,11 @@ namespace OCL
         else
             // special cases:
             if ( act_type == "PeriodicActivity" && period != 0.0)
+                // WARNING RTT::PeriodicActivity does not support a name!
                 newact = new RTT::extras::PeriodicActivity(scheduler, priority, period, cpu_affinity, 0);
             else
             if ( act_type == "NonPeriodicActivity" && period == 0.0)
-                newact = new RTT::Activity(scheduler, priority, period, cpu_affinity, 0);
+                newact = new RTT::Activity(scheduler, priority, period, cpu_affinity, 0, comp_name);
             else
                 if ( act_type == "SlaveActivity" ) {
                     if ( master_act == 0 )
@@ -2116,7 +2117,7 @@ namespace OCL
                         }
 			else if ( act_type == "FileDescriptorActivity") {
 				using namespace RTT::extras;
-                newact = new FileDescriptorActivity(scheduler, priority, period, cpu_affinity, 0);
+                newact = new FileDescriptorActivity(scheduler, priority, period, cpu_affinity, 0, comp_name);
 				FileDescriptorActivity* fdact = dynamic_cast< RTT::extras::FileDescriptorActivity* > (newact);
 				if (fdact) fdact->setTimeout(period);
 				else newact = 0;

--- a/timer/TimerComponent.cpp
+++ b/timer/TimerComponent.cpp
@@ -13,7 +13,7 @@ namespace OCL
 
     TimerComponent::TimerComponent( std::string name /*= "os::Timer" */ )
         : TaskContext( name, PreOperational ), port_timers(32), mtimeoutEvent("timeout"),
-          mtimer( port_timers, mtimeoutEvent ),
+          mtimer( port_timers, mtimeoutEvent, name ),
           waitForCommand( "waitFor", &TimerComponent::waitFor, this), //, &TimerComponent::isTimerExpired, this),
           waitCommand( "wait", &TimerComponent::wait, this) //&TimerComponent::isTimerExpired, this)
     {

--- a/timer/TimerComponent.hpp
+++ b/timer/TimerComponent.hpp
@@ -28,8 +28,8 @@ namespace OCL
         struct TimeoutCatcher : public os::Timer {
             RTT::OutputPort<RTT::os::Timer::TimerId>& me;
             std::vector<RTT::OutputPort<RTT::os::Timer::TimerId>* >& m_port_timers;
-            TimeoutCatcher(std::vector<RTT::OutputPort<RTT::os::Timer::TimerId>* >& port_timers, RTT::OutputPort<RTT::os::Timer::TimerId>&  op) :
-                os::Timer(port_timers.size(), ORO_SCHED_RT, os::HighestPriority),
+            TimeoutCatcher(std::vector<RTT::OutputPort<RTT::os::Timer::TimerId>* >& port_timers, RTT::OutputPort<RTT::os::Timer::TimerId>&  op, const std::string& name) :
+                os::Timer(port_timers.size(), ORO_SCHED_RT, os::HighestPriority, name + ".Timer"),
                 me(op),
 		m_port_timers(port_timers)
             {}


### PR DESCRIPTION
Make it easier to trace threads to their associated component(s)
- Correctly pass component names to activities
- Separate the name of the TimerComponent internal thread from the parent component's thread.