### PR TITLE
deployment:: fix Activities naming in OCL::DeploymentComponent::setNa…

### DIFF
--- a/deployment/DeploymentComponent.cpp
+++ b/deployment/DeploymentComponent.cpp
@@ -2058,7 +2058,7 @@ namespace OCL
                 newact = new RTT::extras::PeriodicActivity(scheduler, priority, period, cpu_affinity, 0);
             else
             if ( act_type == "NonPeriodicActivity" && period == 0.0)
-                newact = new RTT::Activity(scheduler, priority, period, cpu_affinity, 0);
+                newact = new RTT::Activity(scheduler, priority, period, cpu_affinity, 0, comp_name);
             else
                 if ( act_type == "SlaveActivity" ) {
                     if ( master_act == 0 )
@@ -2078,7 +2078,7 @@ namespace OCL
                         }
 			else if ( act_type == "FileDescriptorActivity") {
 				using namespace RTT::extras;
-                newact = new FileDescriptorActivity(scheduler, priority, period, cpu_affinity, 0);
+                newact = new FileDescriptorActivity(scheduler, priority, period, cpu_affinity, 0, comp_name);
 				FileDescriptorActivity* fdact = dynamic_cast< RTT::extras::FileDescriptorActivity* > (newact);
 				if (fdact) fdact->setTimeout(period);
 				else newact = 0;


### PR DESCRIPTION
When `NonPeriodicActivity` or `FileDescriptorActivity` are set for a Component loaded from an xml by the Deployer, the Component's name was not used to set the Activity name that is forwarded to the underlying thread name too.

@meyerj PTAL 