### PR TITLE
taskbrowser: fix editline support

### DIFF
--- a/taskbrowser/CMakeLists.txt
+++ b/taskbrowser/CMakeLists.txt
@@ -2,16 +2,16 @@ OPTION( BUILD_TASKBROWSER "Build TaskBrowser" ON )
 OPTION( TASKBROWSER_EDITLINE "Use editline instead of readline for TaskBrowser." OFF)
 
 IF ( BUILD_TASKBROWSER )
-    IF ( TASKBROWSER_EDITLINE AND NOT EDITLINE)
-      MESSAGE( FATAL_ERROR "Can't build TaskBrowser with editline support since it's not found (see TASKBROWSER_EDITLINE option).")
-    ENDIF ( TASKBROWSER_EDITLINE AND NOT EDITLINE)
-
     #Try to use editline in !GPL or user option:
     IF (NO_GPL OR TASKBROWSER_EDITLINE)
       SET(USE_EDITLINE 1)
     ENDIF (NO_GPL OR TASKBROWSER_EDITLINE)
 
     IF ( USE_EDITLINE )
+      IF ( NOT EDITLINE )
+        MESSAGE( FATAL_ERROR "Can't build TaskBrowser with editline support since it's not found (see TASKBROWSER_EDITLINE option).")
+      ENDIF ( NOT EDITLINE )
+
       MESSAGE( "Building TaskBrowser with editline support." )
     ELSE( USE_EDITLINE )
       IF (READLINE)

--- a/taskbrowser/TaskBrowser.cpp
+++ b/taskbrowser/TaskBrowser.cpp
@@ -162,9 +162,9 @@ namespace OCL
     // All readline specific functions
 #if defined(USE_READLINE)
 
+#if defined(USE_SIGNALS)
     // Signal code only on Posix:
     int TaskBrowser::rl_received_signal;
-#if defined(USE_SIGNALS)
     void TaskBrowser::rl_sigwinch_handler(int sig, siginfo_t *si, void *ctxt) {
         rl_received_signal = sig;
 #if defined(OROCOS_TARGET_XENOMAI) && CONFIG_XENO_VERSION_MAJOR == 2 && CONFIG_XENO_VERSION_MINOR >= 5
@@ -184,7 +184,6 @@ namespace OCL
             }
         }
     }
-#endif // USE_SIGNALS
 
     int TaskBrowser::rl_getc(FILE *stream)
     {
@@ -215,6 +214,7 @@ namespace OCL
                 return (RL_ISSTATE (RL_STATE_READCMD) ? READERR : EOF);
         }
     }
+#endif // USE_SIGNALS
 
     char *TaskBrowser::rl_gets ()
     {
@@ -712,10 +712,10 @@ namespace OCL
 #ifdef USE_SIGNALS
         rl_catch_sigwinch = 0;
         rl_catch_signals = 0;
+        rl_getc_function = &TaskBrowser::rl_getc;
 #endif
         rl_completion_append_character = '\0'; // avoid adding spaces
         rl_attempted_completion_function = &TaskBrowser::orocos_hmi_completion;
-        rl_getc_function = &TaskBrowser::rl_getc;
 
         using_history();
         histfile = getenv("ORO_TB_HISTFILE");

--- a/taskbrowser/TaskBrowser.hpp
+++ b/taskbrowser/TaskBrowser.hpp
@@ -122,13 +122,12 @@ namespace OCL
 #if defined(HAS_READLINE) || defined(HAS_EDITLINE)
 #if defined(_POSIX_VERSION) && !defined(HAS_EDITLINE)
         static void rl_sigwinch_handler(int sig, siginfo_t *si, void *ctxt);
-#endif
-
         static int rl_received_signal;
         static void rl_signal_handler(int sig, siginfo_t *si, void *ctxt);
 
         /* Custom implementation of rl_getc() to handle signals correctly. */
         static int rl_getc(FILE *);
+#endif
 
         /* Read a string, and return a pointer to it.
            Returns NULL on EOF. */


### PR DESCRIPTION
This is a fix for a regression bug reported in #64 and introduced in https://github.com/orocos-toolchain/ocl/pull/7 if the task browser is compiled with [editline](http://thrysoee.dk/editline/) support.

Signal handling is not available in editline and hence

- `OCL::TaskBrowser::rl_received_signal`
- `OCL::TaskBrowser::rl_signal_handler()` and
- `OCL::TaskBrowser::rl_getc()`

must not be defined.

Also fixes `taskbrowser/CMakeLists.txt` which did not check whether editline is actually installed if `NO_GPL` is set but `TASKBROWSER_EDITLINE` is not. Both flags result in compilation with editline support.