### PR TITLE
deployment::DeploymentComponent add keyword this to refer to Deployer

### DIFF
--- a/deployment/DeploymentComponent.cpp
+++ b/deployment/DeploymentComponent.cpp
@@ -970,7 +970,7 @@ namespace OCL
 
                         // Check if we know or are this component.
                         RTT::TaskContext* c = 0;
-                        if ( (*it)->getName() == this->getName() )
+                        if ( (*it)->getName() == "this" || (*it)->getName() == this->getName() )
                             c = this;
                         else
                             c = this->getPeer( (*it)->getName() );
@@ -2011,7 +2011,7 @@ namespace OCL
         // stores it in compmap[comp_name].act
         RTT::TaskContext* peer = 0;
         base::ActivityInterface* master_act = 0;
-        if ( comp_name == this->getName() )
+        if ( comp_name == "this" || comp_name == this->getName() )
             peer = this;
         else
             if ( compmap.count(comp_name) )
@@ -2023,7 +2023,7 @@ namespace OCL
             return false;
         }
         if ( !master_name.empty() ) {
-            if ( master_name == this->getName() )
+            if ( master_name == "this" || master_name == this->getName() )
 	        master_act = this->engine()->getActivity();
             else
                 if ( compmap.count(master_name) && compmap[master_name].act )
@@ -2125,7 +2125,7 @@ namespace OCL
     {
         RTT::Logger::In in("DeploymentComponent");
         RTT::TaskContext* c;
-        if ( name == this->getName() )
+        if ( name == "this" || name == this->getName() )
             c = this;
         else
             c = this->getPeer(name);


### PR DESCRIPTION
This PR adds the possibility to refer to the Deployer using the keyword `this` independently of its name when using xml files.

Example:
```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE properties SYSTEM "cpf.dtd">
<properties>
  <!-- where is our install? -->
  <simple name="Path" type="string">
    <value>lib/orocos</value>
  </simple>

  <!-- load all libraries for our project -->
  <simple name="Import" type="string"><value>kdl_typekit</value></simple>
  <!-- ... -->

  <!-- setup components -->

  <struct name="this" type="">
    <struct name="Properties" type="PropertyBag">
      <simple name="shutdownWait_ms" type="long"><value>50</value></simple>
      <simple name="shutdownTotalWait_ms" type="long"><value>2000</value></simple>
    </struct>
  </struct>

  <!-- ... -->

</properties>
```
Signed-off-by: Luca Magnabosco <luca@intermodalics.eu>