### PR TITLE
ReportingComponent: ComplexDecompose parameter

### DIFF
--- a/reporting/ReportingComponent.cpp
+++ b/reporting/ReportingComponent.cpp
@@ -619,11 +619,11 @@ namespace OCL
         DataSource<bool>::shared_ptr checker;
         for(Reports::iterator it = root.begin(); it != root.end(); ++it ) {
             Property<PropertyBag>* subbag = new Property<PropertyBag>( it->get<T_QualName>(), "");
-			bool decompose_success = false;
-			if ( decompose.get() ) {
-				if ( complexdecompose.get() ) decompose_success = RTT::types::typeDecomposition( it->get<T_PortDS>(), subbag->value(), true );
-				else decompose_success = memberDecomposition( it->get<T_PortDS>(), subbag->value(), checker );
-			}
+            bool decompose_success = false;
+            if ( decompose.get() ) {
+                if ( complexdecompose.get() ) decompose_success = RTT::types::typeDecomposition( it->get<T_PortDS>(), subbag->value(), true );
+                else decompose_success = memberDecomposition( it->get<T_PortDS>(), subbag->value(), checker );
+            }
             if ( decompose_success ) {
                 report.add( subbag );
                 it->get<T_Property>() = subbag;

--- a/reporting/ReportingComponent.hpp
+++ b/reporting/ReportingComponent.hpp
@@ -238,6 +238,7 @@ namespace OCL
         RTT::Property<std::string>   config;
         RTT::Property<bool>          writeHeader;
         RTT::Property<bool>          decompose;
+        RTT::Property<bool>          complexdecompose;
         RTT::Property<bool>          insnapshot;
         RTT::Property<bool>          synchronize_with_logging;
         RTT::Property<PropertyBag>   report_data;


### PR DESCRIPTION
Quickfix for [this issue](https://github.com/orocos-toolchain/ocl/issues/67). 

It allows user to select more robust but slow decomposition procedure to avoid incorrect Reporter output.
 