### PR TITLE
Fix to the problem with displaying service intreface with `unknown_t`

### DIFF
--- a/lua/modules/rttlib.lua
+++ b/lua/modules/rttlib.lua
@@ -292,27 +292,6 @@ function op2str(op)
    return __op2str(op:info())
 end
 
---- Taskcontext operation to string.
--- Old version. Using the op2str and __op2str versions are preferred.
-function tc_op2str(tc, op)
-   local rettype, arity, descr, args = TaskContext.getOpInfo(tc, op)
-   local str = ""
-
-   if #args < 1  then
-      str = rettype .. " " .. cyan(op, false) .. "()"
-   else
-      str = rettype .. " " .. cyan(op, false) .. "("
-
-      for i=1,#args-1 do
-	 str = str .. args[i]["type"] .. " " .. args[i]["name"] .. ", "
-      end
-
-      str = str .. args[#args]["type"] .. " " .. args[#args]["name"] .. ")"
-   end
-   if descr then str = str .. " " .. red("// " .. descr) .. "" end
-   return str
-end
-
 --- Convert a service to a string.
 -- @param s Service
 -- @return string

--- a/lua/modules/rttlib.lua
+++ b/lua/modules/rttlib.lua
@@ -313,6 +313,9 @@ function tc_op2str(tc, op)
    return str
 end
 
+--- Convert a service to a string.
+-- @param s Service
+-- @return string
 function service2str(s, inds, indn)
    local inds = inds or '    '
    local indn = indn or 0
@@ -323,7 +326,7 @@ function service2str(s, inds, indn)
       t[#t+1] = ind .. magenta("Service: ") .. cyan(s:getName(), true)
       t[#t+1] = ind .. magenta("   Subservices: ") .. cyan(table.concat(s:getProviderNames(), ', '))
 
-      t[#t+1] = ind .. magenta("   Ports:       ") -- .. cyan(table.concat(s:getPortNames(), ', '))
+      t[#t+1] = ind .. magenta("   Ports:       ")
       utils.foreach(function(portname)
 		       t[#t+1] = ind .. "        " .. port2str(s:getPort(portname))
 		    end, s:getPortNames())
@@ -340,7 +343,7 @@ function service2str(s, inds, indn)
 
       t[#t+1] = ind .. magenta("   Operations:  ")
       utils.foreach(function(opname)
-		       t[#t+1] = ind .. "        " .. op2str(s:getOperation(opname))
+		       t[#t+1] = ind .. "        " .. __op2str(opname, s:getOperationInfo(opname))
 		    end, s:getOperationNames())
 
       utils.foreach(function (sstr)
@@ -474,7 +477,7 @@ function tc2str(tc, full)
    res[#res+1] = magenta("   Operations") .. ":"
    for i,v in ipairs(TaskContext.getOps(tc)) do
       if not utils.table_has(defops_lst, v) or full then
-	 res[#res+1] = "      " .. tc_op2str(tc, v)
+	 res[#res+1] = "      " .. __op2str(v, TaskContext.getOpInfo(tc, v))
       end
    end
    return table.concat(res, '\n')

--- a/lua/rtt.cpp
+++ b/lua/rtt.cpp
@@ -1973,8 +1973,8 @@ static const struct luaL_Reg Service_f [] = {
 	{ "getProviderNames", Service_getProviderNames },
 	{ "getOperationNames", Service_getOperationNames },
 	{ "hasOperation", Service_hasOperation },
-	{ "getPortNames", Service_getPortNames },
 	{ "getOperationInfo", Service_getOperationInfo },
+	{ "getPortNames", Service_getPortNames },
 	{ "provides", Service_provides },
 	{ "getOperation", Service_getOperation },
 	{ "getPort", Service_getPort },
@@ -2509,7 +2509,7 @@ static int TaskContext_getOps(lua_State *L)
 }
 
 /* returns restype, arity, table-of-arg-descr */
-static int TaskContext_getOpInfo(lua_State *L)
+static int TaskContext_getOperationInfo(lua_State *L)
 {
 	int i=1;
 	TaskContext *tc = *(luaM_checkudata_bx(L, 1, TaskContext));
@@ -2748,7 +2748,8 @@ static const struct luaL_Reg TaskContext_f [] = {
 	{ "getAttributeNames", TaskContext_getAttributeNames },
 	{ "removeAttribute", TaskContext_removeAttribute },
 	{ "getOps", TaskContext_getOps },
-	{ "getOpInfo", TaskContext_getOpInfo },
+	{ "getOpInfo", TaskContext_getOperationInfo },
+	{ "getOperationInfo", TaskContext_getOperationInfo },
 	{ "hasOperation", TaskContext_hasOperation },
 	{ "provides", TaskContext_provides },
 	{ "getProviderNames", TaskContext_getProviderNames },
@@ -2789,7 +2790,8 @@ static const struct luaL_Reg TaskContext_m [] = {
 	{ "removeAttribute", TaskContext_removeAttribute },
 	{ "removeProperty", TaskContext_removeProperty },
 	{ "getOps", TaskContext_getOps },
-	{ "getOpInfo", TaskContext_getOpInfo },
+	{ "getOpInfo", TaskContext_getOperationInfo },
+	{ "getOperationInfo", TaskContext_getOperationInfo },
 	{ "hasOperation", TaskContext_hasOperation },
 	{ "provides", TaskContext_provides },
 	{ "getProviderNames", TaskContext_getProviderNames },


### PR DESCRIPTION
These changes fixes the following problem. If in lua console user tries to display Service interface and one of Operations contains `unknown_t` as parameter then lua exception occurs.  

`TaskContext` interfaces are displayed properly so I modified `service2str` accordingly. 