### PR TITLE
Support connecting dynamically created ports

### DIFF
--- a/deployment/DeploymentComponent.hpp
+++ b/deployment/DeploymentComponent.hpp
@@ -287,8 +287,25 @@ namespace OCL
          */
         bool connectPeers(const std::string& one, const std::string& other);
 
+        /**
+         * Make connection map from the <Ports> tag of \a comp.
+         *
+         * @param comp Property bag describing component to scan the <Ports> tag
+         * of.
+         * @param c The TaskContext instance corresponding to \a comp
+         * @param ignoreNonexistentPorts Whether to ignore ports listed in the
+         * <Ports> tag that do not exist, otherwise to throw an error if such
+         * ports do not exist.
+         *
+         * @return true if all elements in the <Ports> tag are strings (and so
+         * contain port names) and either ignoreNonexistentPorts or
+         * !ignoreNonexistentPorts and all ports named exist in \a c.
+         *
+         * @pre 0 != c
+         */
         bool createConnectionMapFromPortsTag(RTT::Property<RTT::PropertyBag>& comp,
-                                             RTT::TaskContext* c);
+                                             RTT::TaskContext* c,
+                                             const bool ignoreNonexistentPorts);
 
         bool createDataPortConnections();
 

--- a/deployment/DeploymentComponent.hpp
+++ b/deployment/DeploymentComponent.hpp
@@ -287,6 +287,8 @@ namespace OCL
          */
         bool connectPeers(const std::string& one, const std::string& other);
 
+        bool createDataPortConnections();
+
         using TaskContext::connectPorts;
         /**
          * Establish a data flow connection between two tasks. The direction

--- a/deployment/DeploymentComponent.hpp
+++ b/deployment/DeploymentComponent.hpp
@@ -287,6 +287,9 @@ namespace OCL
          */
         bool connectPeers(const std::string& one, const std::string& other);
 
+        bool createConnectionMapFromPortsTag(RTT::Property<RTT::PropertyBag>& comp,
+                                             RTT::TaskContext* c);
+
         bool createDataPortConnections();
 
         using TaskContext::connectPorts;

--- a/deployment/DeploymentComponent.hpp
+++ b/deployment/DeploymentComponent.hpp
@@ -307,7 +307,22 @@ namespace OCL
                                              RTT::TaskContext* c,
                                              const bool ignoreNonexistentPorts);
 
-        bool createDataPortConnections();
+        /**
+         * Create data connections for all known connections in the conmap.
+         * This can be run multiple times, and it will only try to create any
+         * data connections that don't already exist.
+         *
+         * @param skipUnconnected Whether to skip connections that have only
+         * one port. This may occur when the port for one side of a connection
+         * does not yet exist, but will be created later in the deployment
+         * process (e.g. by a component that dynamically creates ports in its
+         * configureHook() ). If skipUnconnected==false then a connection with
+         * only one port will attempt to create a stream for the connection.
+         *
+         * @return true if all connections have an output port and all port
+         * connections were made succesfully.
+         */
+        bool createDataPortConnections(const bool skipUnconnected);
 
         using TaskContext::connectPorts;
         /**

--- a/deployment/tests/deployment.cpf
+++ b/deployment/tests/deployment.cpf
@@ -67,4 +67,20 @@
     <simple name="AutoSave" type="boolean"><value>1</value></simple>
   </struct>
 
+  <!-- Component 4 , already loaded in the application ! -->
+  <struct name="ComponentD" type="PropertyBag">
+    <struct name="Activity" type="Activity">
+      <simple name="Period" type="double"><value>0.2</value></simple>
+      <simple name="Priority" type="short"><value>1</value></simple>
+      <simple name="Scheduler" type="string"><value>ORO_SCHED_RT</value></simple>
+      <simple name="CpuAffinity" type="ushort"><value>3</value></simple>
+    </struct>
+    <simple name="AutoConf" type="boolean"><value>1</value></simple>
+    <simple name="AutoStart" type="boolean"><value>1</value></simple>
+    <struct name="Ports"  type="PropertyBag">
+        <simple name="d2" type="string"><value>AConnection</value></simple>
+        <simple name="d1" type="string"><value>BConnection</value></simple>
+    </struct>
+  </struct>
+
 </properties>

--- a/deployment/tests/main.cpp
+++ b/deployment/tests/main.cpp
@@ -36,6 +36,28 @@ public:
     }
 };
 
+// creates ports dynamically (ie in configureHook() )
+class MyDynamicTask
+: public RTT::TaskContext
+{
+public:
+    InputPort<double> d1;
+    OutputPort<double> d2;
+
+    MyDynamicTask(std::string n)
+        : RTT::TaskContext(n),
+        d1("d1"),
+        d2("d2")
+    {
+    }
+    virtual bool configureHook()
+    {
+        this->ports()->addPort( d1 );
+        this->ports()->addPort( d2 );
+        return true;
+    }
+};
+
 class HelloProvider
     : public RTT::TaskContext
 {
@@ -76,6 +98,7 @@ int ORO_main(int, char**)
     MyTask t1("ComponentA");
     MyTask t2("ComponentB");
     MyTask t3("ComponentC");
+    MyDynamicTask t4("ComponentD");
 
     HelloProvider p;
     HelloRequester r;
@@ -85,6 +108,7 @@ int ORO_main(int, char**)
         dc.addPeer( &t1 );
         dc.addPeer( &t2 );
         dc.addPeer( &t3 );
+        dc.addPeer( &t4 );
         dc.addPeer( &p );
         dc.addPeer( &r );
         dc.kickStart("deployment.cpf");


### PR DESCRIPTION
This PR is picking some commits from @snrkiwi's fork.

The deployer ignores unknown ports in a first pass to create connections and tries again after the configure step, where errors would result in a failure. This allows to create and connect dynamically from the `configureHook().

This is the most important commit message from https://github.com/meyerj/ocl/commit/576c34e40a9fc4dc84a71b08176df595bb0b3877:
> deployment: Support multiple passes of connecting data ports
> The first pass must be tolerant of connections that only have one
> port currently - future ports may complete this connection.
> 
> So during the first pass, when loading components only ports that
> are compiled in to a component (ie created in the component's
> constructor), it is acceptable to have a connection with only one
> port and such a connection is ignored for now.
> 
> During the second pass, after configuring components (and thus any
> ports created during configureHook(), say in response to properties)
> at this point all ports should have been created and a connection
> with only one port shall have a stream created for it.