### PR TITLE
Fix thread naming for components deployed from xml configurations

### DIFF
--- a/deployment/DeploymentComponent.cpp
+++ b/deployment/DeploymentComponent.cpp
@@ -2055,10 +2055,11 @@ namespace OCL
         else
             // special cases:
             if ( act_type == "PeriodicActivity" && period != 0.0)
+                // WARNING RTT::PeriodicActivity does not support a name!
                 newact = new RTT::extras::PeriodicActivity(scheduler, priority, period, cpu_affinity, 0);
             else
             if ( act_type == "NonPeriodicActivity" && period == 0.0)
-                newact = new RTT::Activity(scheduler, priority, period, cpu_affinity, 0);
+                newact = new RTT::Activity(scheduler, priority, period, cpu_affinity, 0, comp_name);
             else
                 if ( act_type == "SlaveActivity" ) {
                     if ( master_act == 0 )
@@ -2078,7 +2079,7 @@ namespace OCL
                         }
 			else if ( act_type == "FileDescriptorActivity") {
 				using namespace RTT::extras;
-                newact = new FileDescriptorActivity(scheduler, priority, period, cpu_affinity, 0);
+                newact = new FileDescriptorActivity(scheduler, priority, period, cpu_affinity, 0, comp_name);
 				FileDescriptorActivity* fdact = dynamic_cast< RTT::extras::FileDescriptorActivity* > (newact);
 				if (fdact) fdact->setTimeout(period);
 				else newact = 0;

--- a/timer/TimerComponent.cpp
+++ b/timer/TimerComponent.cpp
@@ -13,7 +13,7 @@ namespace OCL
 
     TimerComponent::TimerComponent( std::string name /*= "os::Timer" */ )
         : TaskContext( name, PreOperational ), port_timers(32), mtimeoutEvent("timeout"),
-          mtimer( port_timers, mtimeoutEvent ),
+          mtimer( port_timers, mtimeoutEvent, name ),
           waitForCommand( "waitFor", &TimerComponent::waitFor, this), //, &TimerComponent::isTimerExpired, this),
           waitCommand( "wait", &TimerComponent::wait, this) //&TimerComponent::isTimerExpired, this)
     {

--- a/timer/TimerComponent.hpp
+++ b/timer/TimerComponent.hpp
@@ -28,8 +28,8 @@ namespace OCL
         struct TimeoutCatcher : public os::Timer {
             RTT::OutputPort<RTT::os::Timer::TimerId>& me;
             std::vector<RTT::OutputPort<RTT::os::Timer::TimerId>* >& m_port_timers;
-            TimeoutCatcher(std::vector<RTT::OutputPort<RTT::os::Timer::TimerId>* >& port_timers, RTT::OutputPort<RTT::os::Timer::TimerId>&  op) :
-                os::Timer(port_timers.size(), ORO_SCHED_RT, os::HighestPriority),
+            TimeoutCatcher(std::vector<RTT::OutputPort<RTT::os::Timer::TimerId>* >& port_timers, RTT::OutputPort<RTT::os::Timer::TimerId>&  op, const std::string& name) :
+                os::Timer(port_timers.size(), ORO_SCHED_RT, os::HighestPriority, name + ".Timer"),
                 me(op),
 		m_port_timers(port_timers)
             {}


### PR DESCRIPTION
This PR is picking some commits from @snrkiwi's fork.

It passes the thread name from xml deployment configs to the activity instances created for the components, which is especially useful for debugging in combination with https://github.com/orocos-toolchain/rtt/pull/128 and follow-up patches.

Commit messages:
> deployment: Fix passing component name to all activities
> Without this the thread name is set to "FileDescriptorActivity", etc, which
> is useless when multiple of each activity type are present in the deployment.
> The fix is to pass the component name to the activity class constructor, the
> same as with the other Activity derived classes.
> WARNING PeriodicActivity does not support a name, so nothing to do there.

> timer: Name the underlying Timer activity/thread
> Currently the parent component and the internal catcher thread have
> the same name, which is confusing.
> Use the component name + ".Timer". This way the component might get
> "MyTimer", and the internal catcher thread becomes "MyTimer.Timer"
> to separate it from the parent component.
> NB: Thread names have a 15 character limit!