### PR TITLE
deployer: cleanup and unify CORBA deployers and fix shutdown and error reporting

### DIFF
--- a/bin/cdeployer.cpp
+++ b/bin/cdeployer.cpp
@@ -22,9 +22,7 @@
  *   License along with this program; if not, write to the Free Software   *
  *   Foundation, Inc., 59 Temple Place,                                    *
  *   Suite 330, Boston, MA  02111-1307  USA                                *
- *                                                                         *
  ***************************************************************************/
-
 
 #include <rtt/rtt-config.h>
 #ifdef OS_RT_MALLOC
@@ -32,27 +30,26 @@
 #define ORO_MEMORY_POOL
 #include <rtt/os/tlsf/tlsf.h>
 #endif
-
 #include <rtt/os/main.h>
 #include <rtt/RTT.hpp>
+#include <rtt/Logger.hpp>
 
 #include <deployment/CorbaDeploymentComponent.hpp>
 #include <rtt/transports/corba/TaskContextServer.hpp>
 #include <iostream>
+#include <string>
 #include "deployer-funcs.hpp"
 
 #ifdef  ORO_BUILD_LOGGING
 #   ifndef OS_RT_MALLOC
-#   warning Logging needs rtalloc!
+#   warning "Logging needs rtalloc!"
 #   endif
 #include <log4cpp/HierarchyMaintainer.hh>
 #include "logging/Category.hpp"
 #endif
 
-using namespace std;
-using namespace RTT::corba;
 using namespace RTT;
-using namespace OCL;
+using namespace RTT::corba;
 namespace po = boost::program_options;
 
 int main(int argc, char** argv)
@@ -85,23 +82,23 @@ int main(int argc, char** argv)
     // as last set of options
     otherOptions.add(taoOptions);
 
-    // were we given TAO options? ie find "--"
-    int     taoIndex    = 0;
+    // were we given non-deployer options? ie find "--"
+    int     optIndex    = 0;
     bool    found       = false;
 
-    while(!found && taoIndex<argc)
+    while(!found && optIndex<argc)
     {
-        found = (0 == strcmp("--", argv[taoIndex]));
-        if(!found) taoIndex++;
+        found = (0 == strcmp("--", argv[optIndex]));
+        if(!found) optIndex++;
     }
 
     if (found) {
-        argv[taoIndex] = argv[0];
+        argv[optIndex] = argv[0];
     }
 
-    // if TAO options not found then process all command line options,
+    // if extra options not found then process all command line options,
     // otherwise process all options up to but not including "--"
-	int rc = OCL::deployerParseCmdLine(!found ? argc : taoIndex, argv,
+    int rc = OCL::deployerParseCmdLine(!found ? argc : optIndex, argv,
                                        siteFile, scriptFiles, name, requireNameService, deploymentOnlyChecked,
 									   minNumberCPU,
                                        vm, &otherOptions);
@@ -146,6 +143,7 @@ int main(int argc, char** argv)
 #endif  // ORO_BUILD_RTALLOC
 
 #ifdef  ORO_BUILD_LOGGING
+    // use our log4cpp-derived categories to do real-time logging
     log4cpp::HierarchyMaintainer::set_category_factory(
         OCL::logging::Category::createOCLCategory);
 #endif
@@ -155,81 +153,94 @@ int main(int argc, char** argv)
      ***************************************************/
 
     // start Orocos _AFTER_ setting up log4cpp
-	if (0 == __os_init(argc - taoIndex, &argv[taoIndex]))
+	if (0 == __os_init(argc - optIndex, &argv[optIndex]))
     {
 #ifdef  ORO_BUILD_LOGGING
         log(Info) << "OCL factory set for real-time logging" << endlog();
 #endif
-        // scope to force dc destruction prior to memory free
-        {
-            OCL::CorbaDeploymentComponent dc( name, siteFile );
+        rc = -1;     // prove otherwise
+        try {
             // if TAO options not found then have TAO process just the program name,
             // otherwise TAO processes the program name plus all options (potentially
             // none) after "--"
-            TaskContextServer::InitOrb( argc - taoIndex, &argv[taoIndex] );
+            TaskContextServer::InitOrb( argc - optIndex, &argv[optIndex] );
 
-            if (0 == TaskContextServer::Create( &dc, true, requireNameService ))
+            // scope to force dc destruction prior to memory free and Orb shutdown
             {
-                return -1;
-            }
+                OCL::CorbaDeploymentComponent dc( name, siteFile );
 
-            /* Only start the scripts after the Orb was created. Processing of
-               scripts stops after the first failed script, and -1 is returned.
-               Whether a script failed or all scripts succeeded, the CORBA
-               server will be run.
-             */
-            bool result = true;
-            for (std::vector<std::string>::const_iterator iter=scriptFiles.begin();
-                 iter!=scriptFiles.end() && result;
-                 ++iter)
-            {
-                if ( !(*iter).empty() )
+                if (0 == TaskContextServer::Create( &dc, true, requireNameService ))
                 {
-                    if ( (*iter).rfind(".xml",string::npos) == (*iter).length() - 4 || (*iter).rfind(".cpf",string::npos) == (*iter).length() - 4) {
-                        if ( deploymentOnlyChecked ) {
-                            if (!dc.loadComponents( (*iter) )) {
-                                result = false;
-                                log(Error) << "Failed to load file: '"<< (*iter) <<"'." << endlog();
-                            } else if (!dc.configureComponents()) {
-                                result = false;
-                                log(Error) << "Failed to configure file: '"<< (*iter) <<"'." << endlog();
-                            }
-                            // else leave result=true and continue
-                        } else {
-                            result = dc.kickStart( (*iter) );
-                        }
-                        continue;
-                    }
-
-                    if ( (*iter).rfind(".ops",string::npos) == (*iter).length() - 4 ||
-                         (*iter).rfind(".osd",string::npos) == (*iter).length() - 4 ||
-                         (*iter).rfind(".lua",string::npos) == (*iter).length() - 4) {
-                        result = dc.runScript( (*iter) );
-                        continue;
-                    }
-                    log(Error) << "Unknown extension of file: '"<< (*iter) <<"'. Must be xml, cpf for XML files or, ops, osd or lua for script files."<<endlog();
+                    return -1;
                 }
-            }
-            rc = (result ? 0 : -1);
 
-            // Export the DeploymentComponent as CORBA server.
-            if ( !deploymentOnlyChecked ) {
-            	TaskContextServer::RunOrb();
+                /* Only start the scripts after the Orb was created. Processing of
+                   scripts stops after the first failed script, and -1 is returned.
+                   Whether a script failed or all scripts succeeded, the CORBA
+                   server will be run.
+                 */
+                bool result = true;
+                for (std::vector<std::string>::const_iterator iter=scriptFiles.begin();
+                     iter!=scriptFiles.end() && result;
+                     ++iter)
+                {
+                    if ( !(*iter).empty() )
+                    {
+                        if ( (*iter).rfind(".xml",string::npos) == (*iter).length() - 4 || (*iter).rfind(".cpf",string::npos) == (*iter).length() - 4) {
+                            if ( deploymentOnlyChecked ) {
+                                if (!dc.loadComponents( (*iter) )) {
+                                    result = false;
+                                    log(Error) << "Failed to load file: '"<< (*iter) <<"'." << endlog();
+                                } else if (!dc.configureComponents()) {
+                                    result = false;
+                                    log(Error) << "Failed to configure file: '"<< (*iter) <<"'." << endlog();
+                                }
+                                // else leave result=true and continue
+                            } else {
+                                result = dc.kickStart( (*iter) );
+                            }
+                            continue;
+                        }
+
+                        if ( (*iter).rfind(".ops", std::string::npos) == (*iter).length() - 4 ||
+                             (*iter).rfind(".osd", std::string::npos) == (*iter).length() - 4 ||
+                             (*iter).rfind(".lua", std::string::npos) == (*iter).length() - 4) {
+                            result = dc.runScript( (*iter) );
+                            continue;
+                        }
+
+                        log(Error) << "Unknown extension of file: '"<< (*iter) <<"'. Must be xml, cpf for XML files or, ops, osd or lua for script files."<<endlog();
+                    }
+                }
+                rc = (result ? 0 : -1);
+
+                // Export the DeploymentComponent as CORBA server.
+                if ( !deploymentOnlyChecked ) {
+                    TaskContextServer::RunOrb();
+                }
             }
 
             TaskContextServer::ShutdownOrb();
 
             TaskContextServer::DestroyOrb();
 
+        } catch( CORBA::Exception &e ) {
+            log(Error) << argv[0] <<" ORO_main : CORBA exception raised!" << Logger::nl;
+            log() << CORBA_EXCEPTION_INFO(e) << endlog();
+        } catch (...) {
+            // catch this so that we can destroy the TLSF memory correctly
+            log(Error) << "Uncaught exception." << endlog();
         }
 
+        // shutdown Orocos
         __os_exit();
-	}
-	else
-	{
-		std::cerr << "Unable to start Orocos" << std::endl;
-        return -1;
-	}
+    }
+    else
+    {
+        std::cerr << "Unable to start Orocos" << std::endl;
+        rc = -1;
+    }
+
 #ifdef  ORO_BUILD_LOGGING
     log4cpp::HierarchyMaintainer::getDefaultMaintainer().shutdown();
     log4cpp::HierarchyMaintainer::getDefaultMaintainer().deleteAllCategories();

--- a/bin/cdeployer.cpp
+++ b/bin/cdeployer.cpp
@@ -197,7 +197,7 @@ int main(int argc, char** argv)
                                 }
                                 // else leave result=true and continue
                             } else {
-                                result = dc.kickStart( (*iter) );
+                                result = dc.kickStart( (*iter) ) && result;
                             }
                             continue;
                         }
@@ -205,7 +205,7 @@ int main(int argc, char** argv)
                         if ( (*iter).rfind(".ops", std::string::npos) == (*iter).length() - 4 ||
                              (*iter).rfind(".osd", std::string::npos) == (*iter).length() - 4 ||
                              (*iter).rfind(".lua", std::string::npos) == (*iter).length() - 4) {
-                            result = dc.runScript( (*iter) );
+                            result = dc.runScript( (*iter) ) && result;
                             continue;
                         }
 

--- a/bin/deployer-corba.cpp
+++ b/bin/deployer-corba.cpp
@@ -24,7 +24,6 @@
  *   Suite 330, Boston, MA  02111-1307  USA                                *
  ***************************************************************************/
 
-
 #include <rtt/rtt-config.h>
 #ifdef OS_RT_MALLOC
 // need access to all TLSF functions embedded in RTT
@@ -33,11 +32,13 @@
 #endif
 #include <rtt/os/main.h>
 #include <rtt/RTT.hpp>
+#include <rtt/Logger.hpp>
 
 #include <taskbrowser/TaskBrowser.hpp>
 #include <deployment/CorbaDeploymentComponent.hpp>
 #include <rtt/transports/corba/TaskContextServer.hpp>
 #include <iostream>
+#include <string>
 #include "deployer-funcs.hpp"
 
 #include <rtt/transports/corba/corba.h>
@@ -50,7 +51,6 @@
 #include "logging/Category.hpp"
 #endif
 
-using namespace std;
 using namespace RTT;
 using namespace RTT::corba;
 namespace po = boost::program_options;
@@ -58,20 +58,20 @@ namespace po = boost::program_options;
 int main(int argc, char** argv)
 {
 	std::string                 siteFile;      // "" means use default in DeploymentComponent.cpp
-    std::vector<std::string>    scriptFiles;
+	std::vector<std::string>    scriptFiles;
 	std::string                 name("Deployer");
     bool                        requireNameService = false;
     bool                        deploymentOnlyChecked = false;
 	int							minNumberCPU = 0;
-	po::variables_map           vm;
-	po::options_description     taoOptions("Additional options can also be passed to TAO");
+    po::variables_map           vm;
+	po::options_description     taoOptions("Additional options after a '--' are passed through to TAO");
 	// we don't actually list any options for TAO ...
 
 	po::options_description     otherOptions;
 
 #ifdef  ORO_BUILD_RTALLOC
-    OCL::memorySize         rtallocMemorySize   = ORO_DEFAULT_RTALLOC_SIZE;
-	po::options_description rtallocOptions      = OCL::deployerRtallocOptions(rtallocMemorySize);
+    OCL::memorySize             rtallocMemorySize   = ORO_DEFAULT_RTALLOC_SIZE;
+	po::options_description     rtallocOptions      = OCL::deployerRtallocOptions(rtallocMemorySize);
 	otherOptions.add(rtallocOptions);
 #endif
 
@@ -85,31 +85,30 @@ int main(int argc, char** argv)
     // as last set of options
     otherOptions.add(taoOptions);
 
-    // were we given TAO options? ie find "--"
-    int     taoIndex    = 0;
+    // were we given non-deployer options? ie find "--"
+    int     optIndex    = 0;
     bool    found       = false;
 
-    while(!found && taoIndex<argc)
+    while(!found && optIndex<argc)
     {
-        found = (0 == strcmp("--", argv[taoIndex]));
-        if(!found) taoIndex++;
+        found = (0 == strcmp("--", argv[optIndex]));
+        if(!found) optIndex++;
     }
 
     if (found) {
-        argv[taoIndex] = argv[0];
+        argv[optIndex] = argv[0];
     }
 
-    // if TAO options not found then process all command line options,
+    // if extra options not found then process all command line options,
     // otherwise process all options up to but not including "--"
-	int rc = OCL::deployerParseCmdLine(!found ? argc : taoIndex, argv,
-                                       siteFile, scriptFiles, name, requireNameService,deploymentOnlyChecked,
+    int rc = OCL::deployerParseCmdLine(!found ? argc : optIndex, argv,
+                                       siteFile, scriptFiles, name, requireNameService, deploymentOnlyChecked,
 									   minNumberCPU,
                                        vm, &otherOptions);
 	if (0 != rc)
 	{
 		return rc;
 	}
-
 
 	// check system capabilities
 	rc = OCL::enforceMinNumberCPU(minNumberCPU);
@@ -152,8 +151,12 @@ int main(int argc, char** argv)
         OCL::logging::Category::createOCLCategory);
 #endif
 
+    /******************** WARNING ***********************
+     *   NO log(...) statements before __os_init() !!!!! 
+     ***************************************************/
+
     // start Orocos _AFTER_ setting up log4cpp
-	if (0 == __os_init(argc - taoIndex, &argv[taoIndex]))
+	if (0 == __os_init(argc - optIndex, &argv[optIndex]))
     {
 #ifdef  ORO_BUILD_LOGGING
         log(Info) << "OCL factory set for real-time logging" << endlog();
@@ -163,18 +166,18 @@ int main(int argc, char** argv)
             // if TAO options not found then have TAO process just the program name,
             // otherwise TAO processes the program name plus all options (potentially
             // none) after "--"
-            TaskContextServer::InitOrb( argc - taoIndex, &argv[taoIndex] );
+            TaskContextServer::InitOrb( argc - optIndex, &argv[optIndex] );
 
             // scope to force dc destruction prior to memory free and Orb shutdown
             {
                 OCL::CorbaDeploymentComponent dc( name, siteFile );
 
                 if (0 == TaskContextServer::Create( &dc, true, requireNameService ))
-                    {
-                        return -1;
-                    }
+                {
+                    return -1;
+                }
 
-                // The orb thread accepts incomming CORBA calls.
+                // The orb thread accepts incoming CORBA calls.
                 TaskContextServer::ThreadOrb();
 
                 /* Only start the scripts after the Orb was created. Processing of
@@ -206,12 +209,13 @@ int main(int argc, char** argv)
                             continue;
                         }
 
-                        if ( (*iter).rfind(".ops",string::npos) == (*iter).length() - 4 ||
-                             (*iter).rfind(".osd",string::npos) == (*iter).length() - 4 ||
-                             (*iter).rfind(".lua",string::npos) == (*iter).length() - 4) {
+                        if ( (*iter).rfind(".ops", std::string::npos) == (*iter).length() - 4 ||
+                             (*iter).rfind(".osd", std::string::npos) == (*iter).length() - 4 ||
+                             (*iter).rfind(".lua", std::string::npos) == (*iter).length() - 4) {
                             result = dc.runScript( (*iter) );
                             continue;
                         }
+
                         log(Error) << "Unknown extension of file: '"<< (*iter) <<"'. Must be xml, cpf for XML files or, ops, osd or lua for script files."<<endlog();
                     }
                 }
@@ -231,7 +235,6 @@ int main(int argc, char** argv)
 
             TaskContextServer::DestroyOrb();
 
-
         } catch( CORBA::Exception &e ) {
             log(Error) << argv[0] <<" ORO_main : CORBA exception raised!" << Logger::nl;
             log() << CORBA_EXCEPTION_INFO(e) << endlog();
@@ -240,14 +243,19 @@ int main(int argc, char** argv)
             log(Error) << "Uncaught exception." << endlog();
         }
 
-		// shutdown Orocos
-		__os_exit();
-	}
-	else
-	{
-		std::cerr << "Unable to start Orocos" << std::endl;
+        // shutdown Orocos
+        __os_exit();
+    }
+    else
+    {
+        std::cerr << "Unable to start Orocos" << std::endl;
         rc = -1;
-	}
+    }
+
+#ifdef  ORO_BUILD_LOGGING
+    log4cpp::HierarchyMaintainer::getDefaultMaintainer().shutdown();
+    log4cpp::HierarchyMaintainer::getDefaultMaintainer().deleteAllCategories();
+#endif
 
 #ifdef  ORO_BUILD_RTALLOC
     if (!rtMem)

--- a/bin/deployer-corba.cpp
+++ b/bin/deployer-corba.cpp
@@ -204,7 +204,7 @@ int main(int argc, char** argv)
                                 }
                                 // else leave result=true and continue
                             } else {
-                                result = dc.kickStart( (*iter) );
+                                result = dc.kickStart( (*iter) ) && result;
                             }
                             continue;
                         }
@@ -212,7 +212,7 @@ int main(int argc, char** argv)
                         if ( (*iter).rfind(".ops", std::string::npos) == (*iter).length() - 4 ||
                              (*iter).rfind(".osd", std::string::npos) == (*iter).length() - 4 ||
                              (*iter).rfind(".lua", std::string::npos) == (*iter).length() - 4) {
-                            result = dc.runScript( (*iter) );
+                            result = dc.runScript( (*iter) ) && result;
                             continue;
                         }
 

--- a/bin/deployer.cpp
+++ b/bin/deployer.cpp
@@ -207,7 +207,6 @@ int main(int argc, char** argv)
             // We don't start an interactive console when we're a daemon
             if ( !deploymentOnlyChecked && !vm.count("daemon") ) {
                 OCL::TaskBrowser tb( &dc );
-
                 tb.loop();
 
                 dc.shutdownDeployment();

--- a/bin/deployer.cpp
+++ b/bin/deployer.cpp
@@ -56,12 +56,11 @@
 
 using namespace RTT;
 namespace po = boost::program_options;
-using namespace std;
 
 int main(int argc, char** argv)
 {
 	std::string                 siteFile;      // "" means use default in DeploymentComponent.cpp
-    std::vector<std::string>    scriptFiles;
+	std::vector<std::string>    scriptFiles;
 	std::string                 name("Deployer");
     bool                        requireNameService = false;         // not used
     bool                        deploymentOnlyChecked = false;
@@ -99,11 +98,10 @@ int main(int argc, char** argv)
     // if extra options not found then process all command line options,
     // otherwise process all options up to but not including "--"
     int rc = OCL::deployerParseCmdLine(!found ? argc : optIndex, argv,
-                                       siteFile, scriptFiles, name, requireNameService,deploymentOnlyChecked,
+                                       siteFile, scriptFiles, name, requireNameService, deploymentOnlyChecked,
 									   minNumberCPU,
                                        vm, &otherOptions);
-
-    if (0 != rc)
+	if (0 != rc)
 	{
 		return rc;
 	}
@@ -145,6 +143,7 @@ int main(int argc, char** argv)
 #endif  // ORO_BUILD_RTALLOC
 
 #ifdef  ORO_BUILD_LOGGING
+    // use our log4cpp-derived categories to do real-time logging
     log4cpp::HierarchyMaintainer::set_category_factory(
         OCL::logging::Category::createOCLCategory);
 #endif
@@ -160,6 +159,7 @@ int main(int argc, char** argv)
 #ifdef  ORO_BUILD_LOGGING
         log(Info) << "OCL factory set for real-time logging" << endlog();
 #endif
+        rc = -1;     // prove otherwise
         // scope to force dc destruction prior to memory free
         {
             OCL::DeploymentComponent dc( name, siteFile );
@@ -193,12 +193,13 @@ int main(int argc, char** argv)
                         continue;
                     }
 
-                    if ( (*iter).rfind(".ops",std::string::npos) == (*iter).length() - 4 ||
-                         (*iter).rfind(".osd",std::string::npos) == (*iter).length() - 4 ||
-                         (*iter).rfind(".lua",std::string::npos) == (*iter).length() - 4) {
+                    if ( (*iter).rfind(".ops", std::string::npos) == (*iter).length() - 4 ||
+                         (*iter).rfind(".osd", std::string::npos) == (*iter).length() - 4 ||
+                         (*iter).rfind(".lua", std::string::npos) == (*iter).length() - 4) {
                         result = dc.runScript( (*iter) ) && result;
                         continue;
                     }
+
                     log(Error) << "Unknown extension of file: '"<< (*iter) <<"'. Must be xml, cpf for XML files or, ops, osd or lua for script files."<<endlog();
                 }
             }
@@ -226,13 +227,14 @@ int main(int argc, char** argv)
             }
 #endif
 
+        // shutdown Orocos
         __os_exit();
-	}
-	else
-	{
-		std::cerr << "Unable to start Orocos" << std::endl;
+    }
+    else
+    {
+        std::cerr << "Unable to start Orocos" << std::endl;
         rc = -1;
-	}
+    }
 
 #ifdef  ORO_BUILD_LOGGING
     log4cpp::HierarchyMaintainer::getDefaultMaintainer().shutdown();

--- a/bin/deployer.cpp
+++ b/bin/deployer.cpp
@@ -188,7 +188,7 @@ int main(int argc, char** argv)
                             }
                             // else leave result=true and continue
                         } else {
-                            result = dc.kickStart( (*iter) );
+                            result = dc.kickStart( (*iter) ) && result;
                         }
                         continue;
                     }


### PR DESCRIPTION
This pull request is a collection of three functionally independent older commits, but they are all related to the deployer executables and its variants cdeployer and deployer-corba and would cause merge conflicts if applied in arbitrary order.

### [kick out all components before shutdown and destroying the ORB](https://github.com/orocos-toolchain/ocl/commit/6f2496a4872f550d374cf83c05672ddb2ce9ee43?w=1)
- Makes sure that `shutdownDeployment()` is called and the DeploymentComponent is destroyed before the call to `ShutdownOrb()` and `DestroyOrb()`. This allows the components to communicate with remote peers during their stop and cleanup transitions and to cleanly disconnect all connections.
- GitHub has a hard time to format this patch correctly in normal view because indentation changed for large parts of the file. In fact, only very few lines were changed, see https://github.com/orocos-toolchain/ocl/commit/6f2496a4872f550d374cf83c05672ddb2ce9ee43?w=1.

### [fixed OCL::Logging cleanup in deployer-corba](https://github.com/orocos-toolchain/ocl/commit/6d10d0977e8d6a29d68bcdf24811acd4f271f466?w=1)
- lots of minor updates to unify the three deployer implementations, with only minimal functional changes
- cleanup of the OCL::Logging hierarchy as added in 12e97bea for `deployer.cpp`, in 2eae90e5 for `cdeployer.cpp`, but was missing in `deployer-corba.cpp`
- catch CORBA errors in `cdeployer`, like with `deployer-corba`
- Actually the implementation of the executables in `bin/` would deserve another major refactoring because they still contain a lot of duplicated code and a way too long main function.
- Again, best viewed with https://github.com/orocos-toolchain/ocl/commit/6d10d0977e8d6a29d68bcdf24811acd4f271f466?w=1 because of changed indentation.

### [fixed error reporting of deployers if multiple config/script files are given in the command line](https://github.com/orocos-toolchain/ocl/commit/798aca110b4554e14ee76dce2782cee3904bff23?w=1)
- fixes a regression from https://github.com/orocos-toolchain/ocl/commit/ae3cb626c76513c1308548d43f790a669e784836#diff-c65fdb7d93a41cd9995e883385187bd0L166, which broke reporting of errors in the exit status or check-only deployments as introduced in https://github.com/orocos-toolchain/ocl/commit/8107483d901868fe38f3f3cb0541a6bbde3780ad if more than one file is given in the command line
- f482b2b89adc722b577586fe4de120883fc91895 also partially resolved this issue by aborting the loop if one of the files could not be started/run successfully, but the deployer still does not exit immediately and runs the task browser instead. Is this the behavior that we want?