### PR TITLE
bin: add missing std namespace prefixes in deployer sources

### DIFF
--- a/bin/cdeployer.cpp
+++ b/bin/cdeployer.cpp
@@ -132,13 +132,13 @@ int main(int argc, char** argv)
         size_t freeMem = init_memory_pool(memSize, rtMem);
         if ((size_t)-1 == freeMem)
         {
-            cerr << "Invalid memory pool size of " << memSize
-                          << " bytes (TLSF has a several kilobyte overhead)." << endl;
+            std::cerr << "Invalid memory pool size of " << memSize
+                      << " bytes (TLSF has a several kilobyte overhead)." << std::endl;
             free(rtMem);
             return -1;
         }
-        cout << "Real-time memory: " << freeMem << " bytes free of "
-                  << memSize << " allocated." << endl;
+        std::cout << "Real-time memory: " << freeMem << " bytes free of "
+                  << memSize << " allocated." << std::endl;
     }
 #endif  // ORO_BUILD_RTALLOC
 
@@ -186,7 +186,8 @@ int main(int argc, char** argv)
                 {
                     if ( !(*iter).empty() )
                     {
-                        if ( (*iter).rfind(".xml",string::npos) == (*iter).length() - 4 || (*iter).rfind(".cpf",string::npos) == (*iter).length() - 4) {
+                        if ( (*iter).rfind(".xml", std::string::npos) == (*iter).length() - 4 ||
+                             (*iter).rfind(".cpf", std::string::npos) == (*iter).length() - 4) {
                             if ( deploymentOnlyChecked ) {
                                 if (!dc.loadComponents( (*iter) )) {
                                     result = false;

--- a/bin/deployer-corba.cpp
+++ b/bin/deployer-corba.cpp
@@ -135,13 +135,13 @@ int main(int argc, char** argv)
         size_t freeMem = init_memory_pool(memSize, rtMem);
         if ((size_t)-1 == freeMem)
         {
-            cerr << "Invalid memory pool size of " << memSize
-                          << " bytes (TLSF has a several kilobyte overhead)." << endl;
+            std::cerr << "Invalid memory pool size of " << memSize
+                      << " bytes (TLSF has a several kilobyte overhead)." << std::endl;
             free(rtMem);
             return -1;
         }
-        cout << "Real-time memory: " << freeMem << " bytes free of "
-                  << memSize << " allocated." << endl;
+        std::cout << "Real-time memory: " << freeMem << " bytes free of "
+                  << memSize << " allocated." << std::endl;
     }
 #endif  // ORO_BUILD_RTALLOC
 
@@ -193,7 +193,8 @@ int main(int argc, char** argv)
                 {
                     if ( !(*iter).empty() )
                     {
-                        if ( (*iter).rfind(".xml",string::npos) == (*iter).length() - 4 || (*iter).rfind(".cpf",string::npos) == (*iter).length() - 4) {
+                        if ( (*iter).rfind(".xml", std::string::npos) == (*iter).length() - 4 ||
+                             (*iter).rfind(".cpf", std::string::npos) == (*iter).length() - 4) {
                             if ( deploymentOnlyChecked ) {
                                 if (!dc.loadComponents( (*iter) )) {
                                     result = false;

--- a/bin/deployer.cpp
+++ b/bin/deployer.cpp
@@ -132,13 +132,13 @@ int main(int argc, char** argv)
         freeMem = init_memory_pool(memSize, rtMem);
         if ((size_t)-1 == freeMem)
         {
-            cerr << "Invalid memory pool size of " << memSize 
-                          << " bytes (TLSF has a several kilobyte overhead)." << endl;
+            std::cerr << "Invalid memory pool size of " << memSize
+                      << " bytes (TLSF has a several kilobyte overhead)." << std::endl;
             free(rtMem);
             return -1;
         }
-        cout << "Real-time memory: " << freeMem << " bytes free of "
-                  << memSize << " allocated." << endl;
+        std::cout << "Real-time memory: " << freeMem << " bytes free of "
+                  << memSize << " allocated." << std::endl;
     }
 #endif  // ORO_BUILD_RTALLOC
 


### PR DESCRIPTION
This is a regression from https://github.com/orocos-toolchain/ocl/pull/74 (https://github.com/orocos-toolchain/ocl/pull/74/commits/6d10d0977e8d6a29d68bcdf24811acd4f271f466), which removed the `using namespace std` directive, but was picked from a branch were https://github.com/orocos-toolchain/ocl/pull/57 was already applied. The latter moved the tlsf log output from the individual deployers to a centralized class in `deployer-funcs.cpp` and therefore did not require the using namespace directive anymore.