### PR TITLE
Fix compiler warnings with GCC 9

### DIFF
--- a/logging/Appender.cpp
+++ b/logging/Appender.cpp
@@ -141,4 +141,4 @@ void Appender::processEvents(int n)
 }
 }
 
-ORO_LIST_COMPONENT_TYPE(OCL::logging::Appender);
+ORO_LIST_COMPONENT_TYPE(OCL::logging::Appender)

--- a/logging/FileAppender.cpp
+++ b/logging/FileAppender.cpp
@@ -64,4 +64,4 @@ void FileAppender::cleanupHook()
 }
 }
 
-ORO_LIST_COMPONENT_TYPE(OCL::logging::FileAppender);
+ORO_LIST_COMPONENT_TYPE(OCL::logging::FileAppender)

--- a/logging/OstreamAppender.cpp
+++ b/logging/OstreamAppender.cpp
@@ -58,4 +58,4 @@ void OstreamAppender::cleanupHook()
 }
 }
 
-ORO_LIST_COMPONENT_TYPE(OCL::logging::OstreamAppender);
+ORO_LIST_COMPONENT_TYPE(OCL::logging::OstreamAppender)

--- a/logging/RollingFileAppender.cpp
+++ b/logging/RollingFileAppender.cpp
@@ -77,4 +77,4 @@ void RollingFileAppender::cleanupHook()
 }
 }
 
-ORO_LIST_COMPONENT_TYPE(OCL::logging::RollingFileAppender);
+ORO_LIST_COMPONENT_TYPE(OCL::logging::RollingFileAppender)

--- a/lua/rtt.cpp
+++ b/lua/rtt.cpp
@@ -1238,7 +1238,7 @@ static int Port_connect(lua_State *L)
 	PortInterface **pip1, **pip2;
 	PortInterface *pi1 = NULL;
 	PortInterface *pi2 = NULL;
-    ConnPolicy **cpp;
+	ConnPolicy **cpp;
 	ConnPolicy *cp = NULL;
 
 	if((pip1 = (PortInterface**) luaL_testudata(L, 1, "InputPort")) != NULL) {
@@ -1266,10 +1266,10 @@ static int Port_connect(lua_State *L)
 		cp=*cpp;
 	}
 
-    if ( cp )
-        ret = pi1->connectTo(pi2, *cp);
-    else
-        ret = pi1->connectTo(pi2);
+	if ( cp )
+		ret = pi1->connectTo(pi2, *cp);
+	else
+		ret = pi1->connectTo(pi2);
 
 	lua_pushboolean(L, ret);
 
@@ -1291,23 +1291,23 @@ static int Port_disconnect(lua_State *L)
 	else {
 		arg_type = lua_type(L, 1);
 		luaL_error(L, "Port.info: invalid argument 1, expected Port, got %s",
-			   lua_typename(L, arg_type));
-    }
-    if((pip2 = (PortInterface**) luaL_testudata(L, 2, "InputPort")) != NULL) {
-	pi2= *pip2;
-    } else if((pip2 = (PortInterface**) luaL_testudata(L, 2, "OutputPort")) != NULL) {
-	pi2= *pip2;
-    }
+			lua_typename(L, arg_type));
+	}
+	if((pip2 = (PortInterface**) luaL_testudata(L, 2, "InputPort")) != NULL) {
+		pi2= *pip2;
+	} else if((pip2 = (PortInterface**) luaL_testudata(L, 2, "OutputPort")) != NULL) {
+		pi2= *pip2;
+	}
 
-    if (pi2 != NULL)
-	ret = pi1->disconnect(pi2);
-    else{
-	pi1->disconnect();
-	ret = 1;
-    }
-    lua_pushboolean(L, ret);
+	if (pi2 != NULL)
+		ret = pi1->disconnect(pi2);
+	else{
+		pi1->disconnect();
+		ret = 1;
+	}
+	lua_pushboolean(L, ret);
 
-    return 1;
+	return 1;
 }
 
 
@@ -1755,7 +1755,7 @@ static int Service_provides(lua_State *L)
 		subsrv = srv->getService(subsrv_str);
 		if (subsrv == 0)
 			luaL_error(L, "Service.provides: no subservice %s of service %s",
-                       subsrv_str, srv->getName().c_str() );
+				subsrv_str, srv->getName().c_str() );
 		else
 			luaM_pushobject_mt(L, "Service", Service::shared_ptr)(subsrv);
 	}
@@ -2471,7 +2471,7 @@ static int TaskContext_removeAttribute(lua_State *L)
 	if(!tc->attributes()->hasAttribute(name))
 		luaL_error(L, "%s failed. No such attribute", __FILE__);
 
-    tc->attributes()->removeAttribute(name);
+	tc->attributes()->removeAttribute(name);
 
 	return 0;
 }

--- a/reporting/ReportingComponent.cpp
+++ b/reporting/ReportingComponent.cpp
@@ -96,7 +96,11 @@ namespace OCL
         targetbag.setType( dsb->getTypeName() );
 
         // needed for recursion.
+#if __cplusplus < 201103L
         auto_ptr< Property<PropertyBag> > recurse_bag( new Property<PropertyBag>("recurse_bag","") );
+#else
+        unique_ptr< Property<PropertyBag> > recurse_bag( new Property<PropertyBag>("recurse_bag","") );
+#endif
         // First at the explicitly listed parts:
         for(vector<string>::iterator it = parts.begin(); it != parts.end(); ++it ) {
             // we first force getMember to get to the type, then we do it again but with a reference set.

--- a/reporting/TcpReporting.cpp
+++ b/reporting/TcpReporting.cpp
@@ -41,7 +41,7 @@ using RTT::Logger;
 using RTT::os::Mutex;
 
 #include "ocl/Component.hpp"
-ORO_LIST_COMPONENT_TYPE(OCL::TcpReporting);
+ORO_LIST_COMPONENT_TYPE(OCL::TcpReporting)
 
 namespace OCL
 {

--- a/reporting/socket.cpp
+++ b/reporting/socket.cpp
@@ -134,7 +134,7 @@ http://gobby.0x539.de/trac/browser/net6/trunk/src/socket.cpp?rev=224
                 }
             }
     };
-};
+}  // namespace
 
 namespace OCL {
 namespace TCP {
@@ -293,5 +293,5 @@ namespace TCP {
             ::close( _socket );
         }
     }
-};
-};
+}  // namespace TCP
+}  // namespace OCL

--- a/reporting/socket.hpp
+++ b/reporting/socket.hpp
@@ -29,7 +29,7 @@
 
 namespace {
     class sockbuf;
-};
+}
 
 namespace OCL {
 namespace TCP {
@@ -101,6 +101,6 @@ namespace TCP {
              */
             void close();
     };
-};
-};
+}  // namespace TCP
+}  // namespace OCL
 #endif

--- a/taskbrowser/TaskBrowser.cpp
+++ b/taskbrowser/TaskBrowser.cpp
@@ -1606,10 +1606,10 @@ namespace OCL
         if ( context->provides()->getValue( comm ) ) {
             if (debug)
                 cerr << "Found value..."<<nl;
-                this->printResult( context->provides()->getValue( comm )->getDataSource().get(), true );
-                cout << sresult.str()<<nl;
-                sresult.str("");
-                return;
+            this->printResult( context->provides()->getValue( comm )->getDataSource().get(), true );
+            cout << sresult.str()<<nl;
+            sresult.str("");
+            return;
         }
 
         if ( result ) {


### PR DESCRIPTION
Counterpart of https://github.com/orocos-toolchain/rtt/pull/317 for OCL.

Only misleading whitespace (`-Wmisleading-indentation`), redundant semicolons and one usage of deprecated `auto_ptr`.