### PR TITLE
cmake: fix finding package OROCOS-RTT from within orocos-ocl-config.cmake

### DIFF
--- a/orocos-ocl-config.cmake
+++ b/orocos-ocl-config.cmake
@@ -43,7 +43,7 @@
 include(FindPkgConfig)
 
 # Find RTT to get OROCOS_TARGET etc.
-if(NOT OROCOS_TARGET)
+if(NOT OROCOS-RTT_FOUND)
   find_package(OROCOS-RTT REQUIRED)
 endif()
 if(NOT COMMAND orocos_find_package)


### PR DESCRIPTION
If package `OROCOS-RTT` has not been found before, finding package `OROCOS-OCL` is supposed to call `find_package(OROCOS-RTT)` it internally since https://github.com/orocos-toolchain/ocl/commit/6aaec69595ff3f9f8a316b330228ac487d26a86d.

Variable `OROCOS_TARGET` may be defined as a CMake variable at the command line or in the CMake cache, so its evaluation is not an indication of whether CMake package `OROCOS-RTT` has been found before or not. For that it is required to check `<PackageName>_FOUND` according to CMake standards, [which is set by `find_package(OROCOS-RTT)` implicitly](https://cmake.org/cmake/help/latest/command/find_package.html#basic-signature) and explicitly by [orocos-rtt-config.cmake](https://github.com/orocos-toolchain/rtt/blob/600102e8be9c81905b20930e32d43b28244ab173/orocos-rtt-config.cmake#L179).